### PR TITLE
feat: Add flags to CLI

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,5 +29,6 @@ func Execute() {
 
 func init() {
 	persistent := rootCmd.PersistentFlags()
-	persistent.BoolP("disable-slack", "d", false, "Use 'disable-slack' to disable Slack alerts.")
+	persistent.BoolP("disable-slack", "d", false, "Disable Slack alerts.")
+	persistent.StringP("config", "c", "config.toml", "Config file path.")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,5 +28,6 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	persistent := rootCmd.PersistentFlags()
+	persistent.BoolP("disable-slack", "d", false, "Use 'disable-slack' to disable Slack alerts.")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -29,11 +29,11 @@ type TomlConfig struct {
 	Team                  []TeamConfig
 }
 
-func LoadConfig() TomlConfig {
+func LoadConfig(configFilePath *string) TomlConfig {
 	var config TomlConfig
 	log := logger.Get()
 
-	_, err := toml.DecodeFile("config.toml", &config)
+	_, err := toml.DecodeFile(*configFilePath, &config)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Error loading config file.")
 	}

--- a/internal/scan.go
+++ b/internal/scan.go
@@ -236,7 +236,10 @@ func Scan(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	log.Debug().Any("slackMessages", slackMessages).Msg("Messages generated for Slack.")
-	api.SendSlackMessages(slackToken, slackMessages)
+	disableSlack := getBool(cmd.Flags(), "disable-slack")
+	if !disableSlack {
+		log.Debug().Any("slackMessages", slackMessages).Msg("Messages generated for Slack.")
+		api.SendSlackMessages(slackToken, slackMessages)
+	}
 	log.Info().Msg("Done!")
 }

--- a/internal/scan.go
+++ b/internal/scan.go
@@ -146,7 +146,7 @@ func Scan(cmd *cobra.Command, args []string) {
 	// Load the configuration file
 	configFilePath := getString(cmd.Flags(), "config")
 	userConfig := config.LoadConfig(&configFilePath)
-z
+
 	// Gather credentials from the environment
 	err := godotenv.Load(".env")
 	if err != nil {

--- a/internal/scan.go
+++ b/internal/scan.go
@@ -144,8 +144,9 @@ func Scan(cmd *cobra.Command, args []string) {
 	log := logger.Get()
 
 	// Load the configuration file
-	userConfig := config.LoadConfig()
-
+	configFilePath := getString(cmd.Flags(), "config")
+	userConfig := config.LoadConfig(&configFilePath)
+z
 	// Gather credentials from the environment
 	err := godotenv.Load(".env")
 	if err != nil {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -9,7 +9,7 @@ import (
 func checkErr(err error) {
 	log := logger.Get()
 	if err != nil {
-		log.Info().Err(err).Msg("Unexpected error extracting the flag.")
+		log.Fatal().Err(err).Msg("Unexpected error extracting the flag.")
 	}
 }
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -19,3 +19,10 @@ func getBool(flags *pflag.FlagSet, flag string) bool {
 	checkErr(err)
 	return b
 }
+
+// getString return the string value of a flag with the given name
+func getString(flags *pflag.FlagSet, flag string) string {
+	s, err := flags.GetString(flag)
+	checkErr(err)
+	return s
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,0 +1,21 @@
+package internal
+
+import (
+	"vulnbot/logger"
+
+	"github.com/spf13/pflag"
+)
+
+func checkErr(err error) {
+	log := logger.Get()
+	if err != nil {
+		log.Info().Err(err).Msg("Unexpected error extracting the flag.")
+	}
+}
+
+// getBool return the bool value of a flag with the given name
+func getBool(flags *pflag.FlagSet, flag string) bool {
+	b, err := flags.GetBool(flag)
+	checkErr(err)
+	return b
+}


### PR DESCRIPTION
# Changes Made

* Implemented 2 new flags for the CLI.

# Description

As a continuation of the work started in [this PR](https://github.com/underdog-tech/vulnbot/pull/20), this pull request (PR) focuses on enhancing the CLI functionality after the introduction of the new CLI framework and the redefined project structure.

In this PR, I have added 2 new flags that will improve the execution speed and flexibility of the CLI:

* `--disable-slack`: This flag eliminates the need to manually comment out the SLACK_TOKEN from the .env file. Instead, it can now be included when interacting with the CLI, for example: `vulnbot scan --disable-slack`.

* `--config`: This flag allows for specifying a dynamic config file path, providing the flexibility to use a custom `config.toml` file located at any desired location in the system. For example: `vulnbot scan --config /home/jose/config.toml`. 😀
These additions aim to make the CLI more efficient and user-friendly, providing enhanced options for customization and configuration.