### PR TITLE
fix: Rename the module to have a fully qualified name

### DIFF
--- a/api/github.go
+++ b/api/github.go
@@ -2,8 +2,8 @@ package api
 
 import (
 	"context"
-	
-	"vulnbot/logger"
+
+	"github.com/underdog-tech/vulnbot/logger"
 
 	"github.com/shurcooL/githubv4"
 )

--- a/api/slack.go
+++ b/api/slack.go
@@ -2,7 +2,8 @@ package api
 
 import (
 	"fmt"
-	"vulnbot/logger"
+
+	"github.com/underdog-tech/vulnbot/logger"
 
 	"github.com/slack-go/slack"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"vulnbot/logger"
+	"github.com/underdog-tech/vulnbot/logger"
 
 	"github.com/spf13/cobra"
 )
@@ -10,9 +10,9 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "vulnbot",
 	Short: "Vulnbot: Your all-in-one security alert manager.",
-	Long: `Vulnbot is a comprehensive security alert manager designed to keep your code safe from vulnerabilities. 
+	Long: `Vulnbot is a comprehensive security alert manager designed to keep your code safe from vulnerabilities.
 
-It is a versatile bot that can seamlessly integrate with multiple data sources, such as GitHub, and soon Phylum, 
+It is a versatile bot that can seamlessly integrate with multiple data sources, such as GitHub, and soon Phylum,
 Vulnbot empowers developers and security teams to efficiently manage and respond to security threats.`,
 }
 

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1,16 +1,16 @@
 package cmd
 
 import (
-	"vulnbot/internal"
+	"github.com/underdog-tech/vulnbot/internal"
 
 	"github.com/spf13/cobra"
 )
 
 // scanCmd represents the scan command
 var scanCmd = &cobra.Command{
-	Use:   "scan",
-	Short: "",
-	Long: ``,
+	Use:     "scan",
+	Short:   "",
+	Long:    ``,
 	Run:     internal.Scan,
 	Aliases: []string{"s", "scan"},
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,8 @@ package config
 
 import (
 	"fmt"
-	"vulnbot/logger"
+
+	"github.com/underdog-tech/vulnbot/logger"
 
 	"github.com/BurntSushi/toml"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module vulnbot
+module github.com/underdog-tech/vulnbot
 
 go 1.20
 

--- a/internal/scan.go
+++ b/internal/scan.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"vulnbot/api"
-	"vulnbot/config"
-	"vulnbot/logger"
+	"github.com/underdog-tech/vulnbot/api"
+	"github.com/underdog-tech/vulnbot/config"
+	"github.com/underdog-tech/vulnbot/logger"
 
 	"github.com/joho/godotenv"
 	"github.com/shurcooL/githubv4"

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,7 +1,7 @@
 package internal
 
 import (
-	"vulnbot/logger"
+	"github.com/underdog-tech/vulnbot/logger"
 
 	"github.com/spf13/pflag"
 )

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"vulnbot/cmd"
+	"github.com/underdog-tech/vulnbot/cmd"
 )
 
 func main() {


### PR DESCRIPTION
Go expects you to use full paths in module names, even for "local"/"internal" modules.