### PR TITLE
fix: Sort the keys of the ecosystem map instead of using a static list

### DIFF
--- a/reporting/constants.go
+++ b/reporting/constants.go
@@ -9,9 +9,3 @@ const SUMMARY_KEY = "summary"
 func getSeverityReportOrder() []string {
 	return []string{"Critical", "High", "Moderate", "Low"}
 }
-
-// Return the order that we want to report ecosystems in.
-// This is necessary because we cannot declare a constant array in Go.
-func getEcosystemReportOrder() []string {
-	return []string{"Go", "Npm", "Pip", "Rubygems"}
-}

--- a/reporting/slack.go
+++ b/reporting/slack.go
@@ -51,7 +51,8 @@ func (s *SlackReporter) buildSummaryReport(
 	}
 
 	ecosystemReport := "*Breakdown by Ecosystem*\n"
-	ecosystems := getEcosystemReportOrder()
+	ecosystems := maps.Keys(report.VulnsByEcosystem)
+	sort.Strings(ecosystems)
 	for _, ecosystem := range ecosystems {
 		vulnCount, _ := report.VulnsByEcosystem[ecosystem]
 		icon, err := config.GetIconForEcosystem(ecosystem, s.config.Ecosystem)

--- a/reporting/slack_test.go
+++ b/reporting/slack_test.go
@@ -94,10 +94,8 @@ Affected repositories: 2
   Low: 12
 
 *Breakdown by Ecosystem*
-  Go: 0
   Npm: 40
   Pip: 2
-  Rubygems: 0
 `
 
 	actual := reporter.buildSummaryReport("OrgName Dependabot Report for now", 13, report)


### PR DESCRIPTION
This bugged me as I was writing it. We were using a static list of ecosystems to maintain order, which had the side effect that we reported _every_ ecosystem, regardless if there were vulnerabilities present. This changes to sorting instead, which is just better.