### PR TITLE
fix: Use time.Time structs for the reportTime passed to reporters

### DIFF
--- a/internal/scan.go
+++ b/internal/scan.go
@@ -53,7 +53,7 @@ func Scan(cmd *cobra.Command, args []string) {
 	}
 	reporters = append(reporters, &reporting.ConsoleReporter{Config: userConfig})
 
-	reportTime := time.Now().UTC().Unix()
+	reportTime := time.Now().UTC()
 	ghOrgName, allRepos := api.QueryGithubOrgVulnerabilities(ghOrgLogin, *ghClient)
 	repositoryOwners := api.QueryGithubOrgRepositoryOwners(ghOrgLogin, *ghClient)
 	// Count our vulnerabilities

--- a/reporting/console.go
+++ b/reporting/console.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/gookit/color"
 	"github.com/underdog-tech/vulnbot/config"
@@ -41,22 +42,23 @@ func (c *ConsoleReporter) SendSummaryReport(
 	header string,
 	numRepos int,
 	report VulnerabilityReport,
-	reportTime int64,
+	reportTime time.Time,
 	wg *sync.WaitGroup,
 ) error {
 	defer wg.Done()
 	summaryReport := color.Bold.Sprint(header) + "\n"
+	summaryReport += color.Style{color.OpItalic}.Sprint(reportTime.Local().Format(time.RFC1123)) + "\n\n"
 	summaryReport += fmt.Sprintf("Total repositories: %d\n", numRepos)
 	summaryReport += fmt.Sprintf("Total vulnerabilities: %d\n", report.TotalCount)
 	summaryReport += fmt.Sprintf("Affected repositories: %d\n", report.AffectedRepos)
-	summaryReport += color.Bold.Sprint("Breakdown by Severity") + "\n"
+	summaryReport += "\n" + color.Bold.Sprint("Breakdown by Severity") + "\n"
 	severities := getSeverityReportOrder()
 	severityColors := getConsoleSeverityColors()
 	for _, severity := range severities {
 		title := color.HEX(severityColors[severity]).Sprint(severity)
 		summaryReport += fmt.Sprintf("%s: %d\n", title, report.VulnsBySeverity[severity])
 	}
-	summaryReport += color.Bold.Sprint("Breakdown by Ecosystem") + "\n"
+	summaryReport += "\n" + color.Bold.Sprint("Breakdown by Ecosystem") + "\n"
 	ecosystems := maps.Keys(report.VulnsByEcosystem)
 	sort.Strings(ecosystems)
 	ecosystemIcons := getConsoleEcosystemIcons()
@@ -72,7 +74,7 @@ func (c *ConsoleReporter) SendSummaryReport(
 // of this could be quite overwhelming.
 func (c *ConsoleReporter) SendTeamReports(
 	teamReports map[string]map[string]VulnerabilityReport,
-	reportTime int64,
+	reportTime time.Time,
 	wg *sync.WaitGroup,
 ) error {
 	defer wg.Done()

--- a/reporting/console.go
+++ b/reporting/console.go
@@ -47,7 +47,7 @@ func (c *ConsoleReporter) SendSummaryReport(
 ) error {
 	defer wg.Done()
 	summaryReport := color.Bold.Sprint(header) + "\n"
-	summaryReport += color.Style{color.OpItalic}.Sprint(reportTime.Local().Format(time.RFC1123)) + "\n\n"
+	summaryReport += color.Style{color.OpItalic}.Sprint(reportTime.Format(time.RFC1123)) + "\n\n"
 	summaryReport += fmt.Sprintf("Total repositories: %d\n", numRepos)
 	summaryReport += fmt.Sprintf("Total vulnerabilities: %d\n", report.TotalCount)
 	summaryReport += fmt.Sprintf("Affected repositories: %d\n", report.AffectedRepos)

--- a/reporting/console_test.go
+++ b/reporting/console_test.go
@@ -30,19 +30,24 @@ func TestSendConsoleSummaryReport(t *testing.T) {
 	severityColors := getConsoleSeverityColors()
 	ecosystemIcons := getConsoleEcosystemIcons()
 	expected := fmt.Sprintf(`%s
+%s
+
 Total repositories: 13
 Total vulnerabilities: 42
 Affected repositories: 2
+
 %s
 %s: 10
 %s: 10
 %s: 10
 %s: 12
+
 %s
 %s Npm: 40
 %s Pip: 2
 `,
-		color.Bold.Sprint("OrgName Dependabot Report for now"),
+		color.Bold.Sprint("OrgName Dependabot Report"),
+		color.Style{color.OpItalic}.Sprint(TEST_REPORT_TIME_FORMATTED),
 		color.Bold.Sprint("Breakdown by Severity"),
 		color.HEX(severityColors["Critical"]).Sprint("Critical"),
 		color.HEX(severityColors["High"]).Sprint("High"),
@@ -55,7 +60,7 @@ Affected repositories: 2
 
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
-	reporter.SendSummaryReport("OrgName Dependabot Report for now", 13, report, UNIX_TIME, wg)
+	reporter.SendSummaryReport("OrgName Dependabot Report", 13, report, TEST_REPORT_TIME, wg)
 	writer.Close()
 	written, _ := ioutil.ReadAll(reader)
 	os.Stdout = origStdout

--- a/reporting/reporter.go
+++ b/reporting/reporter.go
@@ -1,18 +1,21 @@
 package reporting
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 type Reporter interface {
 	SendSummaryReport(
 		header string,
 		numRepos int,
 		report VulnerabilityReport,
-		reportTime int64,
+		reportTime time.Time,
 		wg *sync.WaitGroup,
 	) error
 	SendTeamReports(
 		teamReports map[string]map[string]VulnerabilityReport,
-		reportTime int64,
+		reportTime time.Time,
 		wg *sync.WaitGroup,
 	) error
 }

--- a/reporting/slack.go
+++ b/reporting/slack.go
@@ -5,12 +5,11 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/underdog-tech/vulnbot/config"
 	"github.com/underdog-tech/vulnbot/logger"
 	"golang.org/x/exp/maps"
-
-	"strconv"
 
 	"github.com/slack-go/slack"
 )
@@ -34,7 +33,7 @@ func (s *SlackReporter) buildSummaryReport(
 	header string,
 	numRepos int,
 	report VulnerabilityReport,
-	reportTime int64,
+	reportTime time.Time,
 ) slack.Message {
 	reportBlocks := []slack.Block{
 		slack.NewHeaderBlock(
@@ -42,7 +41,7 @@ func (s *SlackReporter) buildSummaryReport(
 		),
 		slack.NewDividerBlock(),
 		slack.NewContextBlock("", slack.NewTextBlockObject(
-			slack.PlainTextType, strconv.Itoa(int(reportTime)), false, false,
+			slack.PlainTextType, reportTime.Format(time.RFC1123), false, false,
 		)),
 		slack.NewSectionBlock(
 			slack.NewTextBlockObject(
@@ -108,7 +107,7 @@ func (s *SlackReporter) SendSummaryReport(
 	header string,
 	numRepos int,
 	report VulnerabilityReport,
-	reportTime int64,
+	reportTime time.Time,
 	wg *sync.WaitGroup,
 ) error {
 	defer wg.Done()
@@ -151,7 +150,7 @@ func (s *SlackReporter) buildTeamRepositoryReport(
 func (s *SlackReporter) buildTeamReport(
 	teamID string,
 	repos map[string]VulnerabilityReport,
-	reportTime int64,
+	reportTime time.Time,
 ) *SlackReport {
 	log := logger.Get()
 	teamInfo, err := config.GetTeamConfigBySlug(teamID, s.Config.Team)
@@ -169,7 +168,7 @@ func (s *SlackReporter) buildTeamReport(
 		),
 		slack.NewDividerBlock(),
 		slack.NewContextBlock("", slack.NewTextBlockObject(
-			slack.PlainTextType, strconv.Itoa(int(reportTime)), false, false,
+			slack.PlainTextType, reportTime.Format(time.RFC1123), false, false,
 		)),
 		slack.NewSectionBlock(
 			nil,
@@ -197,7 +196,7 @@ func (s *SlackReporter) buildTeamReport(
 
 func (s *SlackReporter) buildAllTeamReports(
 	teamReports map[string]map[string]VulnerabilityReport,
-	reportTime int64,
+	reportTime time.Time,
 ) []*SlackReport {
 	slackMessages := []*SlackReport{}
 
@@ -212,7 +211,7 @@ func (s *SlackReporter) buildAllTeamReports(
 
 func (s *SlackReporter) SendTeamReports(
 	teamReports map[string]map[string]VulnerabilityReport,
-	reportTime int64,
+	reportTime time.Time,
 	wg *sync.WaitGroup,
 ) error {
 	defer wg.Done()

--- a/reporting/slack_test.go
+++ b/reporting/slack_test.go
@@ -3,9 +3,9 @@ package reporting
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
@@ -13,9 +13,8 @@ import (
 	"github.com/underdog-tech/vulnbot/config"
 )
 
-const (
-	UNIX_TIME = 1672534800
-)
+var TEST_REPORT_TIME time.Time = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+var TEST_REPORT_TIME_FORMATTED string = "Thu, 01 Jan 1970 00:00:00 UTC"
 
 type MockSlackClient struct {
 	mock.Mock
@@ -112,7 +111,7 @@ func TestBuildSlackSummaryReport(t *testing.T) {
 				"elements": []map[string]interface{}{
 					{
 						"type": "plain_text",
-						"text": strconv.Itoa(int(UNIX_TIME)),
+						"text": TEST_REPORT_TIME_FORMATTED,
 					},
 				},
 			},
@@ -182,7 +181,7 @@ func TestBuildSlackSummaryReport(t *testing.T) {
 		},
 	}
 	expected, _ := json.Marshal(expected_data)
-	summary := reporter.buildSummaryReport("OrgName Vulnbot Report", 13, report, UNIX_TIME)
+	summary := reporter.buildSummaryReport("OrgName Vulnbot Report", 13, report, TEST_REPORT_TIME)
 	actual, _ := json.Marshal(summary)
 	assert.JSONEq(t, string(expected), string(actual))
 }
@@ -197,7 +196,7 @@ func TestSendSlackSummaryReportSendsSingleMessage(t *testing.T) {
 
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
-	reporter.SendSummaryReport("Foo", 1, report, UNIX_TIME, wg)
+	reporter.SendSummaryReport("Foo", 1, report, TEST_REPORT_TIME, wg)
 	wg.Wait()
 
 	mockClient.AssertExpectations(t)
@@ -294,7 +293,7 @@ func TestBuildSlackTeamReport(t *testing.T) {
 				"elements": []map[string]interface{}{
 					{
 						"type": "plain_text",
-						"text": strconv.Itoa(int(UNIX_TIME)),
+						"text": TEST_REPORT_TIME_FORMATTED,
 					},
 				},
 			},
@@ -315,7 +314,7 @@ func TestBuildSlackTeamReport(t *testing.T) {
 		},
 	}
 	expected, _ := json.Marshal(expectedData)
-	teamReport := reporter.buildTeamReport("TeamName", repoReports, UNIX_TIME)
+	teamReport := reporter.buildTeamReport("TeamName", repoReports, TEST_REPORT_TIME)
 	actual, _ := json.Marshal(teamReport.Message)
 	// Ensure the Slack Blocks match up
 	assert.JSONEq(t, string(expected), string(actual))
@@ -351,7 +350,7 @@ func TestSendSlackTeamReportsSendsMessagePerTeam(t *testing.T) {
 
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
-	reporter.SendTeamReports(teamReports, UNIX_TIME, wg)
+	reporter.SendTeamReports(teamReports, TEST_REPORT_TIME, wg)
 	wg.Wait()
 
 	mockClient.AssertExpectations(t)


### PR DESCRIPTION
This is a follow-up to #61, this time using `time.Time` structs rather than Unix timestamps. This makes it easier to format them for our various outputs.