### PR TITLE
fix: Ignore archived repositories from data collection

### DIFF
--- a/api/github.go
+++ b/api/github.go
@@ -62,7 +62,11 @@ func QueryGithubOrgVulnerabilities(ghOrgLogin string, ghClient githubv4.Client) 
 		if err != nil {
 			log.Panic().Err(err).Msg("Failed to query GitHub!")
 		}
-		allRepos = append(allRepos, alertQuery.Organization.Repositories.Nodes...)
+		for _, node := range alertQuery.Organization.Repositories.Nodes {
+			if !node.IsArchived {
+				allRepos = append(allRepos, node)
+			}
+		}
 		if !alertQuery.Organization.Repositories.PageInfo.HasNextPage {
 			break
 		}


### PR DESCRIPTION
Fixes #65

Instead of blindly appending all repositories to the reported ones, check whether they are archived first. Ideally this would be a filter in the GraphQL query, but GitHub doesn't currently support that.