### PR TITLE
feat: Improved Dockerfile / build / test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.editorconfig
+.env
+.git/
+.github/
+coverage*
+*.md
+*.toml

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @underdog-tech/vulnbot-contributors

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,38 +2,49 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
-
   build:
     strategy:
       matrix:
-        go: ['1.18', '1.19', '1.20']
-        os: ['windows-2019', 'windows-2022', 'ubuntu-20.04', 'ubuntu-22.04', 'macos-11', 'macos-12']
+        go: ["1.18", "1.19", "1.20"]
+        os:
+          [
+            "windows-2019",
+            "windows-2022",
+            "ubuntu-20.04",
+            "ubuntu-22.04",
+            "macos-11",
+            "macos-12",
+            "macos-13",
+          ]
     env:
       OS: ${{ matrix.os }}
       GO: ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     name: Build & test with Go ${{ matrix.go }} on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go }}
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -v -race -covermode=atomic -coverprofile="coverage.out" -coverpkg=./... ./...
+      - name: Test
+        run: go test -v -race -covermode=atomic -coverprofile="coverage.out" -coverpkg=./... ./...
 
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        env_vars: OS,GO
-        flags: unittests
+      - name: Test Docker image
+        run: docker build . --target=test
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          env_vars: OS,GO
+          flags: unittests


### PR DESCRIPTION
This change does a few things for us:

* Switch to using an official Go Docker image for the build so we can specify what version to build with.
* Distribute using a `distroless` image, which is theoretically slimmer. Funny enough this actually increases the size from ~18.9mb, to ~29.1mb. But that's fine, it's still pretty small as far as Docker images go.
* Now using a non-root user to execute the bin, for a small security win
* Add a (by default unused) "test" stage to the Dockerfile.
* Test the Docker image during every CI build using that new "test" stage
* Add MacOS 13 to the build matrix
* Set up a `CODEOWNERS` file so we get PR review requests automatically. This is unrelated, but just necessary.