### PR TITLE
feat: Add "verbose" and "quiet" flags to control the level of command output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,8 +21,7 @@ Vulnbot empowers developers and security teams to efficiently manage and respond
 
 		if quiet == true {
 			logger.SetLogLevel(zerolog.Disabled)
-		}
-		if verbosity > 0 {
+		} else if verbosity > 0 {
 			if verbosity > 3 {
 				verbosity = 3
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/rs/zerolog"
 	"github.com/underdog-tech/vulnbot/logger"
 
 	"github.com/spf13/cobra"
@@ -14,13 +15,27 @@ var rootCmd = &cobra.Command{
 
 It is a versatile bot that can seamlessly integrate with multiple data sources, such as GitHub, and soon Phylum,
 Vulnbot empowers developers and security teams to efficiently manage and respond to security threats.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		verbosity, _ := cmd.Flags().GetCount("verbose")
+
+		if quiet == true {
+			logger.SetLogLevel(zerolog.Disabled)
+		}
+		if verbosity > 0 {
+			if verbosity > 3 {
+				verbosity = 3
+			}
+			logLevel := logger.DEFAULT_LOG_LEVEL - zerolog.Level(verbosity)
+			logger.SetLogLevel(logLevel)
+		}
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	log := logger.Get()
-
 	err := rootCmd.Execute()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to execute command.")
@@ -31,4 +46,8 @@ func init() {
 	persistent := rootCmd.PersistentFlags()
 	persistent.BoolP("disable-slack", "d", false, "Disable Slack alerts.")
 	persistent.StringP("config", "c", "config.toml", "Config file path.")
+
+	persistent.BoolP("quiet", "q", false, "Suppress all console output. (Mutually exclusive with 'verbose'.)")
+	persistent.CountP("verbose", "v", "More verbose output. Specifying multiple times increases verbosity. (Mutually exclusive with 'quiet'.)")
+	rootCmd.MarkFlagsMutuallyExclusive("verbose", "quiet")
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -14,7 +14,6 @@ import (
 
 const DEFAULT_LOG_LEVEL = zerolog.WarnLevel
 
-var lock = sync.Mutex{}
 var log zerolog.Logger
 var once sync.Once
 
@@ -38,10 +37,8 @@ func Get() zerolog.Logger {
 }
 
 func SetLogLevel(logLevel zerolog.Level) zerolog.Logger {
-	lock.Lock()
 	log := Get()
 	zerolog.SetGlobalLevel(logLevel)
 	log = log.Level(logLevel)
-	lock.Unlock()
 	return log
 }


### PR DESCRIPTION
Fixes #48, #49 

This adds two persistent flags:

* `-q` / `--quiet` -- Mute all log output (You still see the console reporter output, since that's not via a logger.)
* `-v` / `--verbose` -- Increase the level of logging output; can be specified multiple times.
  * `-v` == Info logging
  * `-vv` == Debug logging
  * `-vvv` == Trace logging

These two options are mutually exclusive, and will thus error if you specify both together.

This also increases the default log level from "Info", to "Warn". That does mean there will be less output by default, but that seemed okay to me. The `-vvv` for maximum output is fairly standard.