### PR TITLE
feat: Add new data structures for an abstract representation of projects/findings

### DIFF
--- a/querying/datasource.go
+++ b/querying/datasource.go
@@ -1,0 +1,1 @@
+package querying

--- a/querying/ecosystems.go
+++ b/querying/ecosystems.go
@@ -4,17 +4,17 @@ type FindingEcosystemType string
 
 const (
 	FindingEcosystemApt    FindingEcosystemType = "apt"
-	FindingEcosystemCSharp                      = "csharp"
-	FindingEcosystemDart                        = "dart"
-	FindingEcosystemErlang                      = "erlang"
-	FindingEcosystemGHA                         = "gha" // GitHub Actions
-	FindingEcosystemGo                          = "go"
-	FindingEcosystemJava                        = "java"
-	FindingEcosystemJS                          = "js" // Includes TypeScript
-	FindingEcosystemPHP                         = "php"
-	FindingEcosystemPython                      = "python"
-	FindingEcosystemRPM                         = "rpm"
-	FindingEcosystemRuby                        = "ruby"
-	FindingEcosystemRust                        = "rust"
-	FindingEcosystemSwift                       = "swift"
+	FindingEcosystemCSharp FindingEcosystemType = "csharp"
+	FindingEcosystemDart   FindingEcosystemType = "dart"
+	FindingEcosystemErlang FindingEcosystemType = "erlang"
+	FindingEcosystemGHA    FindingEcosystemType = "gha" // GitHub Actions
+	FindingEcosystemGo     FindingEcosystemType = "go"
+	FindingEcosystemJava   FindingEcosystemType = "java"
+	FindingEcosystemJS     FindingEcosystemType = "js" // Includes TypeScript
+	FindingEcosystemPHP    FindingEcosystemType = "php"
+	FindingEcosystemPython FindingEcosystemType = "python"
+	FindingEcosystemRPM    FindingEcosystemType = "rpm"
+	FindingEcosystemRuby   FindingEcosystemType = "ruby"
+	FindingEcosystemRust   FindingEcosystemType = "rust"
+	FindingEcosystemSwift  FindingEcosystemType = "swift"
 )

--- a/querying/ecosystems.go
+++ b/querying/ecosystems.go
@@ -1,20 +1,20 @@
 package querying
 
-type FindingEcosystemType uint8
+type FindingEcosystemType string
 
 const (
-	FindingEcosystemApt FindingEcosystemType = iota
-	FindingEcosystemCSharp
-	FindingEcosystemDart
-	FindingEcosystemErlang
-	FindingEcosystemGHA // GitHub Actions
-	FindingEcosystemGo
-	FindingEcosystemJava
-	FindingEcosystemJS
-	FindingEcosystemPHP
-	FindingEcosystemPython
-	FindingEcosystemRPM
-	FindingEcosystemRuby
-	FindingEcosystemRust
-	FindingEcosystemSwift
+	FindingEcosystemApt    FindingEcosystemType = "apt"
+	FindingEcosystemCSharp                      = "csharp"
+	FindingEcosystemDart                        = "dart"
+	FindingEcosystemErlang                      = "erlang"
+	FindingEcosystemGHA                         = "gha" // GitHub Actions
+	FindingEcosystemGo                          = "go"
+	FindingEcosystemJava                        = "java"
+	FindingEcosystemJS                          = "js" // Includes TypeScript
+	FindingEcosystemPHP                         = "php"
+	FindingEcosystemPython                      = "python"
+	FindingEcosystemRPM                         = "rpm"
+	FindingEcosystemRuby                        = "ruby"
+	FindingEcosystemRust                        = "rust"
+	FindingEcosystemSwift                       = "swift"
 )

--- a/querying/ecosystems.go
+++ b/querying/ecosystems.go
@@ -1,0 +1,20 @@
+package querying
+
+type FindingEcosystemType uint8
+
+const (
+	FindingEcosystemApt FindingEcosystemType = iota
+	FindingEcosystemCSharp
+	FindingEcosystemDart
+	FindingEcosystemErlang
+	FindingEcosystemGHA // GitHub Actions
+	FindingEcosystemGo
+	FindingEcosystemJava
+	FindingEcosystemJS
+	FindingEcosystemPHP
+	FindingEcosystemPython
+	FindingEcosystemRPM
+	FindingEcosystemRuby
+	FindingEcosystemRust
+	FindingEcosystemSwift
+)

--- a/querying/finding.go
+++ b/querying/finding.go
@@ -1,0 +1,19 @@
+package querying
+
+import "sync"
+
+type FindingIdentifierType uint8
+
+const (
+	FindingIdentifierCVE FindingIdentifierType = iota
+	FindingIdentifierGHSA
+)
+
+type Finding struct {
+	Identifiers map[FindingIdentifierType]string
+	Ecosystem   FindingEcosystemType
+	Severity    FindingSeverityType
+	Description string
+	PackageName string
+	mu          sync.Mutex
+}

--- a/querying/finding.go
+++ b/querying/finding.go
@@ -7,7 +7,7 @@ type FindingIdentifierMap map[FindingIdentifierType]string
 
 const (
 	FindingIdentifierCVE  FindingIdentifierType = "cve"
-	FindingIdentifierGHSA                       = "ghsa"
+	FindingIdentifierGHSA FindingIdentifierType = "ghsa"
 )
 
 type Finding struct {

--- a/querying/finding.go
+++ b/querying/finding.go
@@ -2,12 +2,12 @@ package querying
 
 import "sync"
 
-type FindingIdentifierType uint8
+type FindingIdentifierType string
 type FindingIdentifierMap map[FindingIdentifierType]string
 
 const (
-	FindingIdentifierCVE FindingIdentifierType = iota
-	FindingIdentifierGHSA
+	FindingIdentifierCVE  FindingIdentifierType = "cve"
+	FindingIdentifierGHSA                       = "ghsa"
 )
 
 type Finding struct {

--- a/querying/finding.go
+++ b/querying/finding.go
@@ -3,6 +3,7 @@ package querying
 import "sync"
 
 type FindingIdentifierType uint8
+type FindingIdentifierMap map[FindingIdentifierType]string
 
 const (
 	FindingIdentifierCVE FindingIdentifierType = iota
@@ -10,7 +11,7 @@ const (
 )
 
 type Finding struct {
-	Identifiers map[FindingIdentifierType]string
+	Identifiers FindingIdentifierMap
 	Ecosystem   FindingEcosystemType
 	Severity    FindingSeverityType
 	Description string

--- a/querying/project.go
+++ b/querying/project.go
@@ -62,7 +62,7 @@ func (c *ProjectCollection) GetProject(name string) *Project {
 	return newProj
 }
 
-func (p *Project) GetFinding(identifiers map[FindingIdentifierType]string) *Finding {
+func (p *Project) GetFinding(identifiers FindingIdentifierMap) *Finding {
 	var result *Finding
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/querying/project.go
+++ b/querying/project.go
@@ -1,0 +1,76 @@
+package querying
+
+import (
+	"strings"
+	"sync"
+
+	"golang.org/x/exp/maps"
+)
+
+type ProjectCollection struct {
+	Projects []*Project
+	mu       sync.Mutex
+}
+
+type Project struct {
+	Name     string
+	Findings []*Finding
+	Links    map[string]string
+	mu       sync.Mutex
+}
+
+func NewProject(name string) *Project {
+	return &Project{
+		Name:     name,
+		Findings: []*Finding{},
+		Links:    map[string]string{},
+	}
+}
+
+func NewProjectCollection() *ProjectCollection {
+	return &ProjectCollection{
+		Projects: []*Project{},
+	}
+}
+
+func normalizeProjectName(name string) string {
+	return strings.Replace(strings.ToLower(name), "-", "_", -1)
+}
+
+func (c *ProjectCollection) AddProject(name string) *Project {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	name = normalizeProjectName(name)
+	for _, proj := range c.Projects {
+		if normalizeProjectName(proj.Name) == name {
+			return proj
+		}
+	}
+	// If we make it past the loop, no existing project was found with this name
+	newProj := NewProject(name)
+	c.Projects = append(c.Projects, newProj)
+	return newProj
+}
+
+func (p *Project) AddFinding(identifiers map[FindingIdentifierType]string) *Finding {
+	var result *Finding
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, finding := range p.Findings {
+		for idType, id := range finding.Identifiers {
+			val, ok := identifiers[idType]
+			if ok && val == id {
+				result = finding
+				break
+			}
+		}
+	}
+	if result == nil {
+		result = &Finding{
+			Identifiers: identifiers,
+		}
+	} else {
+		maps.Copy(result.Identifiers, identifiers)
+	}
+	return result
+}

--- a/querying/project.go
+++ b/querying/project.go
@@ -36,13 +36,21 @@ func NewProjectCollection() *ProjectCollection {
 	}
 }
 
-// normalizeProjectName converts a project name to a standard normalized baseline.
+// normalizeProjectName converts a project name to a standard normalized format.
 // This means stripping out all characters which are not: Letters, numbers,
 // spaces, hyphens, or underscores. This is done via a regex, which includes the
 // unicode character classes (\p) of `{L}` to represent all letters, and `{N}`
 // to represent all numbers.
 // Once all undesirable characters have been stripped, both spaces and hyphens
 // are converted to underscores, and the resulting string is lower-cased.
+//
+// For example:
+//
+//	$$$ This Project is MONEY! $$$
+//
+// will be normalized to
+//
+//	this_project_is_money
 func normalizeProjectName(name string) string {
 	unacceptableChars := regexp.MustCompile(`[^\p{L}\p{N} \-\_]+`)
 	replacer := strings.NewReplacer(
@@ -50,8 +58,10 @@ func normalizeProjectName(name string) string {
 		"-", "_",
 	)
 	return replacer.Replace(
-		unacceptableChars.ReplaceAllString(
-			strings.ToLower(name), "",
+		strings.TrimSpace(
+			unacceptableChars.ReplaceAllString(
+				strings.ToLower(name), "",
+			),
 		),
 	)
 }

--- a/querying/project.go
+++ b/querying/project.go
@@ -1,6 +1,7 @@
 package querying
 
 import (
+	"regexp"
 	"strings"
 	"sync"
 
@@ -34,7 +35,16 @@ func NewProjectCollection() *ProjectCollection {
 }
 
 func normalizeProjectName(name string) string {
-	return strings.Replace(strings.ToLower(name), "-", "_", -1)
+	unacceptableChars := regexp.MustCompile(`[^\p{L}\p{N} \-\_]+`)
+	replacer := strings.NewReplacer(
+		" ", "_",
+		"-", "_",
+	)
+	return replacer.Replace(
+		unacceptableChars.ReplaceAllString(
+			strings.ToLower(name), "",
+		),
+	)
 }
 
 func (c *ProjectCollection) AddProject(name string) *Project {

--- a/querying/project.go
+++ b/querying/project.go
@@ -47,7 +47,7 @@ func normalizeProjectName(name string) string {
 	)
 }
 
-func (c *ProjectCollection) AddProject(name string) *Project {
+func (c *ProjectCollection) GetProject(name string) *Project {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	name = normalizeProjectName(name)
@@ -62,7 +62,7 @@ func (c *ProjectCollection) AddProject(name string) *Project {
 	return newProj
 }
 
-func (p *Project) AddFinding(identifiers map[FindingIdentifierType]string) *Finding {
+func (p *Project) GetFinding(identifiers map[FindingIdentifierType]string) *Finding {
 	var result *Finding
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -79,7 +79,10 @@ func (p *Project) AddFinding(identifiers map[FindingIdentifierType]string) *Find
 		result = &Finding{
 			Identifiers: identifiers,
 		}
+		p.Findings = append(p.Findings, result)
 	} else {
+		result.mu.Lock()
+		defer result.mu.Unlock()
 		maps.Copy(result.Identifiers, identifiers)
 	}
 	return result

--- a/querying/project.go
+++ b/querying/project.go
@@ -20,6 +20,7 @@ type Project struct {
 	mu       sync.Mutex
 }
 
+// NewProject returns a new, empty project with no links or findings.
 func NewProject(name string) *Project {
 	return &Project{
 		Name:     name,
@@ -28,12 +29,20 @@ func NewProject(name string) *Project {
 	}
 }
 
+// NewProjectCollection returns a new, empty ProjectCollection object.
 func NewProjectCollection() *ProjectCollection {
 	return &ProjectCollection{
 		Projects: []*Project{},
 	}
 }
 
+// normalizeProjectName converts a project name to a standard normalized baseline.
+// This means stripping out all characters which are not: Letters, numbers,
+// spaces, hyphens, or underscores. This is done via a regex, which includes the
+// unicode character classes (\p) of `{L}` to represent all letters, and `{N}`
+// to represent all numbers.
+// Once all undesirable characters have been stripped, both spaces and hyphens
+// are converted to underscores, and the resulting string is lower-cased.
 func normalizeProjectName(name string) string {
 	unacceptableChars := regexp.MustCompile(`[^\p{L}\p{N} \-\_]+`)
 	replacer := strings.NewReplacer(
@@ -47,6 +56,8 @@ func normalizeProjectName(name string) string {
 	)
 }
 
+// GetProject returns the project with the specified name from the collection.
+// If such a project does not yet exist, it is created and added to the collection.
 func (c *ProjectCollection) GetProject(name string) *Project {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -62,6 +73,8 @@ func (c *ProjectCollection) GetProject(name string) *Project {
 	return newProj
 }
 
+// GetFinding returns the specified finding from the project, based on the identifiers.
+// If such a finding does not yet exist, it is created and added to the project.
 func (p *Project) GetFinding(identifiers FindingIdentifierMap) *Finding {
 	var result *Finding
 	p.mu.Lock()

--- a/querying/project_test.go
+++ b/querying/project_test.go
@@ -1,0 +1,30 @@
+package querying_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/underdog-tech/vulnbot/querying"
+)
+
+func TestAddProjectAddsToCollection(t *testing.T) {
+	projects := querying.NewProjectCollection()
+	assert.Len(t, projects.Projects, 0)
+	proj := projects.AddProject("Improbability Drive")
+	assert.Len(t, projects.Projects, 1)
+	assert.Equal(t, proj, projects.Projects[0])
+}
+
+func TestProjectNameIsNormalized(t *testing.T) {
+	projects := querying.NewProjectCollection()
+	proj := projects.AddProject("Heart-of-Gold: Improbability Drive!")
+	assert.Equal(t, "heart_of_gold_improbability_drive", proj.Name)
+}
+
+func TestProjectsAreNotDuplicated(t *testing.T) {
+	projects := querying.NewProjectCollection()
+	proj1 := projects.AddProject("Improbability Drive")
+	proj2 := projects.AddProject("Improbability Drive")
+	assert.Len(t, projects.Projects, 1)
+	assert.Equal(t, proj1, proj2)
+}

--- a/querying/project_test.go
+++ b/querying/project_test.go
@@ -7,24 +7,24 @@ import (
 	"github.com/underdog-tech/vulnbot/querying"
 )
 
-func TestAddProjectAddsToCollection(t *testing.T) {
+func TestGetProjectAddsToCollection(t *testing.T) {
 	projects := querying.NewProjectCollection()
 	assert.Len(t, projects.Projects, 0)
-	proj := projects.AddProject("Improbability Drive")
+	proj := projects.GetProject("Improbability Drive")
 	assert.Len(t, projects.Projects, 1)
 	assert.Equal(t, proj, projects.Projects[0])
 }
 
 func TestProjectNameIsNormalized(t *testing.T) {
 	projects := querying.NewProjectCollection()
-	proj := projects.AddProject("Heart-of-Gold: Improbability Drive!")
+	proj := projects.GetProject("Heart-of-Gold: Improbability Drive!")
 	assert.Equal(t, "heart_of_gold_improbability_drive", proj.Name)
 }
 
 func TestProjectsAreNotDuplicated(t *testing.T) {
 	projects := querying.NewProjectCollection()
-	proj1 := projects.AddProject("Improbability Drive")
-	proj2 := projects.AddProject("Improbability Drive")
+	proj1 := projects.GetProject("Improbability Drive")
+	proj2 := projects.GetProject("Improbability Drive")
 	assert.Len(t, projects.Projects, 1)
 	assert.Equal(t, proj1, proj2)
 }

--- a/querying/project_test.go
+++ b/querying/project_test.go
@@ -28,3 +28,43 @@ func TestProjectsAreNotDuplicated(t *testing.T) {
 	assert.Len(t, projects.Projects, 1)
 	assert.Equal(t, proj1, proj2)
 }
+
+func TestGetFindingAddsToProject(t *testing.T) {
+	project := querying.NewProject("Improbability Drive")
+	assert.Len(t, project.Findings, 0)
+	finding := project.GetFinding(
+		querying.FindingIdentifierMap{
+			querying.FindingIdentifierCVE: "CVE-42",
+		},
+	)
+	assert.Len(t, project.Findings, 1)
+	assert.Equal(t, finding, project.Findings[0])
+}
+
+func TestFindingsAreNotDuplicated(t *testing.T) {
+	project := querying.NewProject("Improbability Drive")
+	identifiers := querying.FindingIdentifierMap{
+		querying.FindingIdentifierCVE: "CVE-42",
+	}
+	finding1 := project.GetFinding(identifiers)
+	finding2 := project.GetFinding(identifiers)
+	assert.Len(t, project.Findings, 1)
+	assert.Equal(t, finding1, finding2)
+}
+
+func TestFindingIdentifiersAreMerged(t *testing.T) {
+	project := querying.NewProject("Improbability Drive")
+	id_single := querying.FindingIdentifierMap{
+		querying.FindingIdentifierCVE: "CVE-42",
+	}
+	id_multi := querying.FindingIdentifierMap{
+		querying.FindingIdentifierCVE:  "CVE-42",
+		querying.FindingIdentifierGHSA: "GHSA-4242",
+	}
+	finding1 := project.GetFinding(id_single)
+	finding2 := project.GetFinding(id_multi)
+	assert.Len(t, project.Findings, 1)
+	assert.Equal(t, finding1, finding2)
+	assert.Equal(t, finding1.Identifiers, id_multi)
+	assert.Equal(t, project.Findings[0].Identifiers, id_multi)
+}

--- a/querying/severities.go
+++ b/querying/severities.go
@@ -1,0 +1,12 @@
+package querying
+
+type FindingSeverityType uint8
+
+const (
+	FindingSeverityCritical FindingSeverityType = iota
+	FindingSeverityHigh
+	FindingSeverityModerate
+	FindingSeverityLow
+	FindingSeverityInfo
+	FindingSeverityUndefined
+)


### PR DESCRIPTION
Fixes #47 

This is my first stab at a proposed data structure for data sources to represent their findings, grouped by project. I believe it would end up being used something like this (very much not valid code):

```go
// scan.go
// ...
projects := NewProjectCollection()
for _, ds := range datasources {
    ds.CollectFindings(projects)
}

// github.go (GitHub datasource)
// ... call the GraphQL API ...
for _, repo := range result.repositories {
    project := projects.GetProject(repo.Name)
    for _, vuln := range repo.VulnerabilityAlerts {
        finding := project.GetFinding(vuln.SecurityAdvisory.Identifiers)
        if finding.Description == "" {
            finding.Description = vuln.SecurityAdvisory.Summary
        }
    }
}
```