### PR TITLE
feat: New functionality for summarizing the new project/finding structures

### DIFF
--- a/internal/summary.go
+++ b/internal/summary.go
@@ -142,6 +142,7 @@ func GroupTeamFindings(projects *querying.ProjectCollection, summaries []Project
 		for _, sum := range summaries {
 			if sum.Name == project.Name {
 				projectSummary = sum
+				break
 			}
 		}
 		ownerIter := project.Owners.Iterator()

--- a/internal/summary.go
+++ b/internal/summary.go
@@ -132,6 +132,8 @@ func (r TeamProjectCollection) Less(i, j int) bool {
 	return r[i].Name < r[j].Name
 }
 
+// GroupTeamFindings gathers a map of each team and the summaries of the projects
+// that team "owns", and should receive reports for.
 func GroupTeamFindings(projects *querying.ProjectCollection, summaries []ProjectFindingSummary) map[config.TeamConfig]TeamProjectCollection {
 	teamProjects := map[config.TeamConfig]TeamProjectCollection{}
 

--- a/internal/summary.go
+++ b/internal/summary.go
@@ -125,10 +125,9 @@ func (r TeamProjectCollection) Swap(i, j int) {
 // Sort projects by criticality of findings, then by name
 func (r TeamProjectCollection) Less(i, j int) bool {
 	sevOne := r[i].GetHighestCriticality()
-	sevTwo := r[i].GetHighestCriticality()
+	sevTwo := r[j].GetHighestCriticality()
 	if sevOne != sevTwo {
-		// Since these are iotas, a lower criticality is a higher number
-		return sevOne > sevTwo
+		return sevOne < sevTwo
 	}
 	return r[i].Name < r[j].Name
 }

--- a/internal/summary.go
+++ b/internal/summary.go
@@ -1,0 +1,152 @@
+package internal
+
+import (
+	"github.com/underdog-tech/vulnbot/config"
+	"github.com/underdog-tech/vulnbot/querying"
+)
+
+var SeverityNames = map[querying.FindingSeverityType]string{
+	querying.FindingSeverityCritical:  "Critical",
+	querying.FindingSeverityHigh:      "High",
+	querying.FindingSeverityModerate:  "Moderate",
+	querying.FindingSeverityLow:       "Low",
+	querying.FindingSeverityInfo:      "Info",
+	querying.FindingSeverityUndefined: "Undefined",
+}
+
+// NewSeverityMap returns a map of finding severities all associated with a
+// value of 0, meant to be populated with a count of findings in the relevant
+// scope. Notably, this map does not include either "Info" or "Undefined"
+// severities, as these are only reported if present.
+func NewSeverityMap() map[querying.FindingSeverityType]int {
+	return map[querying.FindingSeverityType]int{
+		querying.FindingSeverityCritical: 0,
+		querying.FindingSeverityHigh:     0,
+		querying.FindingSeverityModerate: 0,
+		querying.FindingSeverityLow:      0,
+	}
+}
+
+// GetSeverityReportOrder returns the order in which we want to report severities.
+// This is necessary because we cannot declare a constant array in Go.
+func GetSeverityReportOrder() []querying.FindingSeverityType {
+	return []querying.FindingSeverityType{
+		querying.FindingSeverityCritical,
+		querying.FindingSeverityHigh,
+		querying.FindingSeverityModerate,
+		querying.FindingSeverityLow,
+		querying.FindingSeverityInfo,
+		querying.FindingSeverityUndefined,
+	}
+}
+
+type FindingSummary struct {
+	TotalCount       int
+	AffectedRepos    int
+	VulnsByEcosystem map[querying.FindingEcosystemType]int
+	VulnsBySeverity  map[querying.FindingSeverityType]int
+}
+
+type ProjectFindingSummary struct {
+	FindingSummary
+
+	Name string
+}
+
+// GetHighestCriticality looks for the severity level of the most critical
+// vulnerability in a project.
+func (r FindingSummary) GetHighestCriticality() querying.FindingSeverityType {
+	severities := GetSeverityReportOrder()
+	for _, sev := range severities {
+		count, exists := r.VulnsBySeverity[sev]
+		if exists && count > 0 {
+			return sev
+		}
+	}
+	return querying.FindingSeverityUndefined
+}
+
+func NewFindingSummary() FindingSummary {
+	return FindingSummary{
+		AffectedRepos:    0,
+		TotalCount:       0,
+		VulnsByEcosystem: map[querying.FindingEcosystemType]int{},
+		VulnsBySeverity:  NewSeverityMap(),
+	}
+}
+
+func NewProjectFindingSummary(name string) ProjectFindingSummary {
+	summary := NewFindingSummary()
+	return ProjectFindingSummary{Name: name, FindingSummary: summary}
+}
+
+func SummarizeFindings(projects *querying.ProjectCollection) (FindingSummary, []ProjectFindingSummary) {
+	affectedRepos, vulnCount := 0, 0
+	summary := NewFindingSummary()
+	projectReportCollection := []ProjectFindingSummary{}
+
+	for _, project := range projects.Projects {
+		projectReport := NewProjectFindingSummary(project.Name)
+		if numFindings := len(project.Findings); numFindings > 0 {
+			affectedRepos += 1
+			vulnCount += numFindings
+			projectReport.AffectedRepos = 1
+			projectReport.TotalCount = numFindings
+			// For each finding, add its ecosystem and severity tally to both
+			// the summary report and the project-specific report
+			for _, finding := range project.Findings {
+				summary.VulnsByEcosystem[finding.Ecosystem] += 1
+				summary.VulnsBySeverity[finding.Severity] += 1
+
+				projectReport.VulnsByEcosystem[finding.Ecosystem] += 1
+				projectReport.VulnsBySeverity[finding.Severity] += 1
+			}
+		}
+		projectReportCollection = append(projectReportCollection, projectReport)
+	}
+	summary.AffectedRepos = affectedRepos
+	summary.TotalCount = vulnCount
+
+	return summary, projectReportCollection
+}
+
+// TeamProjectCollection is a concrete type so that it can implement the sort
+// interface, for custom sorting.
+type TeamProjectCollection []*ProjectFindingSummary
+
+func (r TeamProjectCollection) Len() int {
+	return len(r)
+}
+
+func (r TeamProjectCollection) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+// Sort projects by criticality of findings, then by name
+func (r TeamProjectCollection) Less(i, j int) bool {
+	sevOne := r[i].GetHighestCriticality()
+	sevTwo := r[i].GetHighestCriticality()
+	if sevOne != sevTwo {
+		// Since these are iotas, a lower criticality is a higher number
+		return sevOne > sevTwo
+	}
+	return r[i].Name < r[j].Name
+}
+
+func GroupTeamFindings(projects *querying.ProjectCollection, summaries []ProjectFindingSummary) map[config.TeamConfig]TeamProjectCollection {
+	teamProjects := map[config.TeamConfig]TeamProjectCollection{}
+
+	for _, project := range projects.Projects {
+		projectSummary := ProjectFindingSummary{}
+		for _, sum := range summaries {
+			if sum.Name == project.Name {
+				projectSummary = sum
+			}
+		}
+		ownerIter := project.Owners.Iterator()
+		for owner := range ownerIter.C {
+			teamProjects[owner] = append(teamProjects[owner], &projectSummary)
+		}
+	}
+	return teamProjects
+}

--- a/internal/summary_test.go
+++ b/internal/summary_test.go
@@ -1,0 +1,118 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/underdog-tech/vulnbot/internal"
+	"github.com/underdog-tech/vulnbot/querying"
+)
+
+// We want a fairly comprehensive collection, to generate a few different numbers
+var testProjectFindings = querying.ProjectCollection{
+	Projects: []*querying.Project{
+		{
+			Name: "foo",
+			Findings: []*querying.Finding{
+				{
+					Ecosystem: querying.FindingEcosystemGo,
+					Severity:  querying.FindingSeverityCritical,
+					Identifiers: querying.FindingIdentifierMap{
+						querying.FindingIdentifierCVE: "CVE-1",
+					},
+				},
+				{
+					Ecosystem: querying.FindingEcosystemPython,
+					Severity:  querying.FindingSeverityHigh,
+					Identifiers: querying.FindingIdentifierMap{
+						querying.FindingIdentifierCVE: "CVE-2",
+					},
+				},
+			},
+		},
+		{
+			Name: "bar",
+			Findings: []*querying.Finding{
+				{
+					Ecosystem: querying.FindingEcosystemGo,
+					Severity:  querying.FindingSeverityInfo,
+					Identifiers: querying.FindingIdentifierMap{
+						querying.FindingIdentifierCVE: "CVE-3",
+					},
+				},
+				{
+					Ecosystem: querying.FindingEcosystemJS,
+					Severity:  querying.FindingSeverityCritical,
+					Identifiers: querying.FindingIdentifierMap{
+						querying.FindingIdentifierCVE: "CVE-4",
+					},
+				},
+			},
+		},
+		{
+			Name:     "baz",
+			Findings: []*querying.Finding{},
+		},
+	},
+}
+
+func TestSummarizeGeneratesOverallSummary(t *testing.T) {
+	severities := internal.NewSeverityMap()
+	severities[querying.FindingSeverityCritical] = 2
+	severities[querying.FindingSeverityHigh] = 1
+	severities[querying.FindingSeverityInfo] = 1
+	expected := internal.FindingSummary{
+		AffectedRepos: 2,
+		TotalCount:    4,
+		VulnsByEcosystem: map[querying.FindingEcosystemType]int{
+			querying.FindingEcosystemGo:     2,
+			querying.FindingEcosystemJS:     1,
+			querying.FindingEcosystemPython: 1,
+		},
+		VulnsBySeverity: severities,
+	}
+	actual, _ := internal.SummarizeFindings(&testProjectFindings)
+	assert.Equal(t, expected, actual)
+}
+
+func TestSummarizeGeneratesProjectReports(t *testing.T) {
+	fooSeverities := internal.NewSeverityMap()
+	fooSeverities[querying.FindingSeverityCritical] = 1
+	fooSeverities[querying.FindingSeverityHigh] = 1
+	foo := internal.ProjectFindingSummary{
+		Name: "foo",
+		FindingSummary: internal.FindingSummary{
+			AffectedRepos: 1,
+			TotalCount:    2,
+			VulnsByEcosystem: map[querying.FindingEcosystemType]int{
+				querying.FindingEcosystemGo:     1,
+				querying.FindingEcosystemPython: 1,
+			},
+			VulnsBySeverity: fooSeverities,
+		},
+	}
+
+	barSeverities := internal.NewSeverityMap()
+	barSeverities[querying.FindingSeverityCritical] = 1
+	barSeverities[querying.FindingSeverityInfo] = 1
+	bar := internal.ProjectFindingSummary{
+		Name: "bar",
+		FindingSummary: internal.FindingSummary{
+			AffectedRepos: 1,
+			TotalCount:    2,
+			VulnsByEcosystem: map[querying.FindingEcosystemType]int{
+				querying.FindingEcosystemGo: 1,
+				querying.FindingEcosystemJS: 1,
+			},
+			VulnsBySeverity: barSeverities,
+		},
+	}
+
+	expected := []internal.ProjectFindingSummary{
+		foo,
+		bar,
+		internal.NewProjectFindingSummary("baz"),
+	}
+	_, actual := internal.SummarizeFindings(&testProjectFindings)
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
> **Note**
> Starting this as a draft PR as it needs more tests still.

This builds upon the work in #75, #77, and #78 to continue toward more generic project/finding structures. The goal of this particular PR is to build code for generating the overall & team-based summaries of the projects and findings.

> **Warning**
> Some of this code will likely move out to the `reporting` package when all is said and done, so don't pay too much mind to that. I have kept this all where it is in order to isolate it from existing code, so that everything will continue working as-is until we can plumb this in. If everything goes well, that should be the next step.