### PR TITLE
feat: Move ecosystem and severity code into config package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,16 +10,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-type SeverityConfig struct {
-	Label       string
-	Slack_emoji string
-}
-
-type EcosystemConfig struct {
-	Label       string
-	Slack_emoji string
-}
-
 type TeamConfig struct {
 	Name          string
 	Github_slug   string

--- a/config/ecosystems.go
+++ b/config/ecosystems.go
@@ -18,3 +18,18 @@ const (
 	FindingEcosystemRust   FindingEcosystemType = "rust"
 	FindingEcosystemSwift  FindingEcosystemType = "swift"
 )
+
+func GetConsoleEcosystemIcons() map[FindingEcosystemType]string {
+	return map[FindingEcosystemType]string{
+		FindingEcosystemGo:     "🦦",
+		FindingEcosystemJava:   "🪶 ",
+		FindingEcosystemJS:     "⬢ ",
+		FindingEcosystemPython: "🐍",
+		FindingEcosystemRuby:   "♦️ ",
+	}
+}
+
+type EcosystemConfig struct {
+	Label       string
+	Slack_emoji string
+}

--- a/config/ecosystems.go
+++ b/config/ecosystems.go
@@ -1,4 +1,4 @@
-package querying
+package config
 
 type FindingEcosystemType string
 

--- a/config/severities.go
+++ b/config/severities.go
@@ -10,3 +10,38 @@ const (
 	FindingSeverityInfo
 	FindingSeverityUndefined
 )
+
+var SeverityNames = map[FindingSeverityType]string{
+	FindingSeverityCritical:  "Critical",
+	FindingSeverityHigh:      "High",
+	FindingSeverityModerate:  "Moderate",
+	FindingSeverityLow:       "Low",
+	FindingSeverityInfo:      "Info",
+	FindingSeverityUndefined: "Undefined",
+}
+
+// NewSeverityMap returns a map of finding severities all associated with a
+// value of 0, meant to be populated with a count of findings in the relevant
+// scope. Notably, this map does not include either "Info" or "Undefined"
+// severities, as these are only reported if present.
+func NewSeverityMap() map[FindingSeverityType]int {
+	return map[FindingSeverityType]int{
+		FindingSeverityCritical: 0,
+		FindingSeverityHigh:     0,
+		FindingSeverityModerate: 0,
+		FindingSeverityLow:      0,
+	}
+}
+
+// GetSeverityReportOrder returns the order in which we want to report severities.
+// This is necessary because we cannot declare a constant array in Go.
+func GetSeverityReportOrder() []FindingSeverityType {
+	return []FindingSeverityType{
+		FindingSeverityCritical,
+		FindingSeverityHigh,
+		FindingSeverityModerate,
+		FindingSeverityLow,
+		FindingSeverityInfo,
+		FindingSeverityUndefined,
+	}
+}

--- a/config/severities.go
+++ b/config/severities.go
@@ -1,4 +1,4 @@
-package querying
+package config
 
 type FindingSeverityType uint8
 

--- a/config/severities.go
+++ b/config/severities.go
@@ -45,3 +45,19 @@ func GetSeverityReportOrder() []FindingSeverityType {
 		FindingSeverityUndefined,
 	}
 }
+
+func GetConsoleSeverityColors() map[FindingSeverityType]string {
+	return map[FindingSeverityType]string{
+		FindingSeverityCritical:  "#B21515",
+		FindingSeverityHigh:      "#D26C00",
+		FindingSeverityModerate:  "#FBD100",
+		FindingSeverityLow:       "#233EB5",
+		FindingSeverityInfo:      "#56B8F5",
+		FindingSeverityUndefined: "#CFD0D1",
+	}
+}
+
+type SeverityConfig struct {
+	Label       string
+	Slack_emoji string
+}

--- a/internal/summary.go
+++ b/internal/summary.go
@@ -5,41 +5,6 @@ import (
 	"github.com/underdog-tech/vulnbot/querying"
 )
 
-var SeverityNames = map[config.FindingSeverityType]string{
-	config.FindingSeverityCritical:  "Critical",
-	config.FindingSeverityHigh:      "High",
-	config.FindingSeverityModerate:  "Moderate",
-	config.FindingSeverityLow:       "Low",
-	config.FindingSeverityInfo:      "Info",
-	config.FindingSeverityUndefined: "Undefined",
-}
-
-// NewSeverityMap returns a map of finding severities all associated with a
-// value of 0, meant to be populated with a count of findings in the relevant
-// scope. Notably, this map does not include either "Info" or "Undefined"
-// severities, as these are only reported if present.
-func NewSeverityMap() map[config.FindingSeverityType]int {
-	return map[config.FindingSeverityType]int{
-		config.FindingSeverityCritical: 0,
-		config.FindingSeverityHigh:     0,
-		config.FindingSeverityModerate: 0,
-		config.FindingSeverityLow:      0,
-	}
-}
-
-// GetSeverityReportOrder returns the order in which we want to report severities.
-// This is necessary because we cannot declare a constant array in Go.
-func GetSeverityReportOrder() []config.FindingSeverityType {
-	return []config.FindingSeverityType{
-		config.FindingSeverityCritical,
-		config.FindingSeverityHigh,
-		config.FindingSeverityModerate,
-		config.FindingSeverityLow,
-		config.FindingSeverityInfo,
-		config.FindingSeverityUndefined,
-	}
-}
-
 type FindingSummary struct {
 	TotalCount       int
 	AffectedRepos    int
@@ -56,7 +21,7 @@ type ProjectFindingSummary struct {
 // GetHighestCriticality looks for the severity level of the most critical
 // vulnerability in a project.
 func (r FindingSummary) GetHighestCriticality() config.FindingSeverityType {
-	severities := GetSeverityReportOrder()
+	severities := config.GetSeverityReportOrder()
 	for _, sev := range severities {
 		count, exists := r.VulnsBySeverity[sev]
 		if exists && count > 0 {
@@ -71,7 +36,7 @@ func NewFindingSummary() FindingSummary {
 		AffectedRepos:    0,
 		TotalCount:       0,
 		VulnsByEcosystem: map[config.FindingEcosystemType]int{},
-		VulnsBySeverity:  NewSeverityMap(),
+		VulnsBySeverity:  config.NewSeverityMap(),
 	}
 }
 

--- a/internal/summary.go
+++ b/internal/summary.go
@@ -5,46 +5,46 @@ import (
 	"github.com/underdog-tech/vulnbot/querying"
 )
 
-var SeverityNames = map[querying.FindingSeverityType]string{
-	querying.FindingSeverityCritical:  "Critical",
-	querying.FindingSeverityHigh:      "High",
-	querying.FindingSeverityModerate:  "Moderate",
-	querying.FindingSeverityLow:       "Low",
-	querying.FindingSeverityInfo:      "Info",
-	querying.FindingSeverityUndefined: "Undefined",
+var SeverityNames = map[config.FindingSeverityType]string{
+	config.FindingSeverityCritical:  "Critical",
+	config.FindingSeverityHigh:      "High",
+	config.FindingSeverityModerate:  "Moderate",
+	config.FindingSeverityLow:       "Low",
+	config.FindingSeverityInfo:      "Info",
+	config.FindingSeverityUndefined: "Undefined",
 }
 
 // NewSeverityMap returns a map of finding severities all associated with a
 // value of 0, meant to be populated with a count of findings in the relevant
 // scope. Notably, this map does not include either "Info" or "Undefined"
 // severities, as these are only reported if present.
-func NewSeverityMap() map[querying.FindingSeverityType]int {
-	return map[querying.FindingSeverityType]int{
-		querying.FindingSeverityCritical: 0,
-		querying.FindingSeverityHigh:     0,
-		querying.FindingSeverityModerate: 0,
-		querying.FindingSeverityLow:      0,
+func NewSeverityMap() map[config.FindingSeverityType]int {
+	return map[config.FindingSeverityType]int{
+		config.FindingSeverityCritical: 0,
+		config.FindingSeverityHigh:     0,
+		config.FindingSeverityModerate: 0,
+		config.FindingSeverityLow:      0,
 	}
 }
 
 // GetSeverityReportOrder returns the order in which we want to report severities.
 // This is necessary because we cannot declare a constant array in Go.
-func GetSeverityReportOrder() []querying.FindingSeverityType {
-	return []querying.FindingSeverityType{
-		querying.FindingSeverityCritical,
-		querying.FindingSeverityHigh,
-		querying.FindingSeverityModerate,
-		querying.FindingSeverityLow,
-		querying.FindingSeverityInfo,
-		querying.FindingSeverityUndefined,
+func GetSeverityReportOrder() []config.FindingSeverityType {
+	return []config.FindingSeverityType{
+		config.FindingSeverityCritical,
+		config.FindingSeverityHigh,
+		config.FindingSeverityModerate,
+		config.FindingSeverityLow,
+		config.FindingSeverityInfo,
+		config.FindingSeverityUndefined,
 	}
 }
 
 type FindingSummary struct {
 	TotalCount       int
 	AffectedRepos    int
-	VulnsByEcosystem map[querying.FindingEcosystemType]int
-	VulnsBySeverity  map[querying.FindingSeverityType]int
+	VulnsByEcosystem map[config.FindingEcosystemType]int
+	VulnsBySeverity  map[config.FindingSeverityType]int
 }
 
 type ProjectFindingSummary struct {
@@ -55,7 +55,7 @@ type ProjectFindingSummary struct {
 
 // GetHighestCriticality looks for the severity level of the most critical
 // vulnerability in a project.
-func (r FindingSummary) GetHighestCriticality() querying.FindingSeverityType {
+func (r FindingSummary) GetHighestCriticality() config.FindingSeverityType {
 	severities := GetSeverityReportOrder()
 	for _, sev := range severities {
 		count, exists := r.VulnsBySeverity[sev]
@@ -63,14 +63,14 @@ func (r FindingSummary) GetHighestCriticality() querying.FindingSeverityType {
 			return sev
 		}
 	}
-	return querying.FindingSeverityUndefined
+	return config.FindingSeverityUndefined
 }
 
 func NewFindingSummary() FindingSummary {
 	return FindingSummary{
 		AffectedRepos:    0,
 		TotalCount:       0,
-		VulnsByEcosystem: map[querying.FindingEcosystemType]int{},
+		VulnsByEcosystem: map[config.FindingEcosystemType]int{},
 		VulnsBySeverity:  NewSeverityMap(),
 	}
 }

--- a/internal/summary_test.go
+++ b/internal/summary_test.go
@@ -18,15 +18,15 @@ var testProjectFindings = querying.ProjectCollection{
 			Name: "foo",
 			Findings: []*querying.Finding{
 				{
-					Ecosystem: querying.FindingEcosystemGo,
-					Severity:  querying.FindingSeverityCritical,
+					Ecosystem: config.FindingEcosystemGo,
+					Severity:  config.FindingSeverityCritical,
 					Identifiers: querying.FindingIdentifierMap{
 						querying.FindingIdentifierCVE: "CVE-1",
 					},
 				},
 				{
-					Ecosystem: querying.FindingEcosystemPython,
-					Severity:  querying.FindingSeverityHigh,
+					Ecosystem: config.FindingEcosystemPython,
+					Severity:  config.FindingSeverityHigh,
 					Identifiers: querying.FindingIdentifierMap{
 						querying.FindingIdentifierCVE: "CVE-2",
 					},
@@ -37,15 +37,15 @@ var testProjectFindings = querying.ProjectCollection{
 			Name: "bar",
 			Findings: []*querying.Finding{
 				{
-					Ecosystem: querying.FindingEcosystemGo,
-					Severity:  querying.FindingSeverityInfo,
+					Ecosystem: config.FindingEcosystemGo,
+					Severity:  config.FindingSeverityInfo,
 					Identifiers: querying.FindingIdentifierMap{
 						querying.FindingIdentifierCVE: "CVE-3",
 					},
 				},
 				{
-					Ecosystem: querying.FindingEcosystemJS,
-					Severity:  querying.FindingSeverityCritical,
+					Ecosystem: config.FindingEcosystemJS,
+					Severity:  config.FindingSeverityCritical,
 					Identifiers: querying.FindingIdentifierMap{
 						querying.FindingIdentifierCVE: "CVE-4",
 					},
@@ -61,16 +61,16 @@ var testProjectFindings = querying.ProjectCollection{
 
 func TestSummarizeGeneratesOverallSummary(t *testing.T) {
 	severities := internal.NewSeverityMap()
-	severities[querying.FindingSeverityCritical] = 2
-	severities[querying.FindingSeverityHigh] = 1
-	severities[querying.FindingSeverityInfo] = 1
+	severities[config.FindingSeverityCritical] = 2
+	severities[config.FindingSeverityHigh] = 1
+	severities[config.FindingSeverityInfo] = 1
 	expected := internal.FindingSummary{
 		AffectedRepos: 2,
 		TotalCount:    4,
-		VulnsByEcosystem: map[querying.FindingEcosystemType]int{
-			querying.FindingEcosystemGo:     2,
-			querying.FindingEcosystemJS:     1,
-			querying.FindingEcosystemPython: 1,
+		VulnsByEcosystem: map[config.FindingEcosystemType]int{
+			config.FindingEcosystemGo:     2,
+			config.FindingEcosystemJS:     1,
+			config.FindingEcosystemPython: 1,
 		},
 		VulnsBySeverity: severities,
 	}
@@ -80,32 +80,32 @@ func TestSummarizeGeneratesOverallSummary(t *testing.T) {
 
 func TestSummarizeGeneratesProjectReports(t *testing.T) {
 	fooSeverities := internal.NewSeverityMap()
-	fooSeverities[querying.FindingSeverityCritical] = 1
-	fooSeverities[querying.FindingSeverityHigh] = 1
+	fooSeverities[config.FindingSeverityCritical] = 1
+	fooSeverities[config.FindingSeverityHigh] = 1
 	foo := internal.ProjectFindingSummary{
 		Name: "foo",
 		FindingSummary: internal.FindingSummary{
 			AffectedRepos: 1,
 			TotalCount:    2,
-			VulnsByEcosystem: map[querying.FindingEcosystemType]int{
-				querying.FindingEcosystemGo:     1,
-				querying.FindingEcosystemPython: 1,
+			VulnsByEcosystem: map[config.FindingEcosystemType]int{
+				config.FindingEcosystemGo:     1,
+				config.FindingEcosystemPython: 1,
 			},
 			VulnsBySeverity: fooSeverities,
 		},
 	}
 
 	barSeverities := internal.NewSeverityMap()
-	barSeverities[querying.FindingSeverityCritical] = 1
-	barSeverities[querying.FindingSeverityInfo] = 1
+	barSeverities[config.FindingSeverityCritical] = 1
+	barSeverities[config.FindingSeverityInfo] = 1
 	bar := internal.ProjectFindingSummary{
 		Name: "bar",
 		FindingSummary: internal.FindingSummary{
 			AffectedRepos: 1,
 			TotalCount:    2,
-			VulnsByEcosystem: map[querying.FindingEcosystemType]int{
-				querying.FindingEcosystemGo: 1,
-				querying.FindingEcosystemJS: 1,
+			VulnsByEcosystem: map[config.FindingEcosystemType]int{
+				config.FindingEcosystemGo: 1,
+				config.FindingEcosystemJS: 1,
 			},
 			VulnsBySeverity: barSeverities,
 		},
@@ -141,13 +141,13 @@ func TestGetHighestCriticality(t *testing.T) {
 
 func TestGetHighestCriticalityNoFindings(t *testing.T) {
 	summary := internal.NewProjectFindingSummary("foo")
-	assert.Equal(t, summary.GetHighestCriticality(), querying.FindingSeverityUndefined)
+	assert.Equal(t, summary.GetHighestCriticality(), config.FindingSeverityUndefined)
 }
 
 func TestSortTeamProjectCollection(t *testing.T) {
 	fooSeverities := internal.NewSeverityMap()
-	fooSeverities[querying.FindingSeverityCritical] = 1
-	fooSeverities[querying.FindingSeverityHigh] = 1
+	fooSeverities[config.FindingSeverityCritical] = 1
+	fooSeverities[config.FindingSeverityHigh] = 1
 	foo := internal.ProjectFindingSummary{
 		Name: "foo",
 		FindingSummary: internal.FindingSummary{
@@ -158,8 +158,8 @@ func TestSortTeamProjectCollection(t *testing.T) {
 	}
 
 	barSeverities := internal.NewSeverityMap()
-	barSeverities[querying.FindingSeverityCritical] = 1
-	barSeverities[querying.FindingSeverityInfo] = 1
+	barSeverities[config.FindingSeverityCritical] = 1
+	barSeverities[config.FindingSeverityInfo] = 1
 	bar := internal.ProjectFindingSummary{
 		Name: "bar",
 		FindingSummary: internal.FindingSummary{
@@ -170,7 +170,7 @@ func TestSortTeamProjectCollection(t *testing.T) {
 	}
 
 	bazSeverities := internal.NewSeverityMap()
-	bazSeverities[querying.FindingSeverityModerate] = 1
+	bazSeverities[config.FindingSeverityModerate] = 1
 	baz := internal.ProjectFindingSummary{
 		Name: "baz",
 		FindingSummary: internal.FindingSummary{

--- a/internal/summary_test.go
+++ b/internal/summary_test.go
@@ -60,7 +60,7 @@ var testProjectFindings = querying.ProjectCollection{
 }
 
 func TestSummarizeGeneratesOverallSummary(t *testing.T) {
-	severities := internal.NewSeverityMap()
+	severities := config.NewSeverityMap()
 	severities[config.FindingSeverityCritical] = 2
 	severities[config.FindingSeverityHigh] = 1
 	severities[config.FindingSeverityInfo] = 1
@@ -79,7 +79,7 @@ func TestSummarizeGeneratesOverallSummary(t *testing.T) {
 }
 
 func TestSummarizeGeneratesProjectReports(t *testing.T) {
-	fooSeverities := internal.NewSeverityMap()
+	fooSeverities := config.NewSeverityMap()
 	fooSeverities[config.FindingSeverityCritical] = 1
 	fooSeverities[config.FindingSeverityHigh] = 1
 	foo := internal.ProjectFindingSummary{
@@ -95,7 +95,7 @@ func TestSummarizeGeneratesProjectReports(t *testing.T) {
 		},
 	}
 
-	barSeverities := internal.NewSeverityMap()
+	barSeverities := config.NewSeverityMap()
 	barSeverities[config.FindingSeverityCritical] = 1
 	barSeverities[config.FindingSeverityInfo] = 1
 	bar := internal.ProjectFindingSummary{
@@ -121,10 +121,10 @@ func TestSummarizeGeneratesProjectReports(t *testing.T) {
 }
 
 func TestGetHighestCriticality(t *testing.T) {
-	severities := internal.GetSeverityReportOrder()
+	severities := config.GetSeverityReportOrder()
 	for _, severity := range severities {
 		t.Run(string(severity), func(t *testing.T) {
-			sevMap := internal.NewSeverityMap()
+			sevMap := config.NewSeverityMap()
 			sevMap[severity] = 1
 			summary := internal.ProjectFindingSummary{
 				Name: "foo",
@@ -145,7 +145,7 @@ func TestGetHighestCriticalityNoFindings(t *testing.T) {
 }
 
 func TestSortTeamProjectCollection(t *testing.T) {
-	fooSeverities := internal.NewSeverityMap()
+	fooSeverities := config.NewSeverityMap()
 	fooSeverities[config.FindingSeverityCritical] = 1
 	fooSeverities[config.FindingSeverityHigh] = 1
 	foo := internal.ProjectFindingSummary{
@@ -157,7 +157,7 @@ func TestSortTeamProjectCollection(t *testing.T) {
 		},
 	}
 
-	barSeverities := internal.NewSeverityMap()
+	barSeverities := config.NewSeverityMap()
 	barSeverities[config.FindingSeverityCritical] = 1
 	barSeverities[config.FindingSeverityInfo] = 1
 	bar := internal.ProjectFindingSummary{
@@ -169,7 +169,7 @@ func TestSortTeamProjectCollection(t *testing.T) {
 		},
 	}
 
-	bazSeverities := internal.NewSeverityMap()
+	bazSeverities := config.NewSeverityMap()
 	bazSeverities[config.FindingSeverityModerate] = 1
 	baz := internal.ProjectFindingSummary{
 		Name: "baz",

--- a/querying/finding.go
+++ b/querying/finding.go
@@ -1,6 +1,10 @@
 package querying
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/underdog-tech/vulnbot/config"
+)
 
 type FindingIdentifierType string
 type FindingIdentifierMap map[FindingIdentifierType]string
@@ -12,8 +16,8 @@ const (
 
 type Finding struct {
 	Identifiers FindingIdentifierMap
-	Ecosystem   FindingEcosystemType
-	Severity    FindingSeverityType
+	Ecosystem   config.FindingEcosystemType
+	Severity    config.FindingSeverityType
 	Description string
 	PackageName string
 	mu          sync.Mutex

--- a/querying/github.go
+++ b/querying/github.go
@@ -81,19 +81,19 @@ type orgVulnerabilityQuery struct {
 }
 
 // Ref: https://docs.github.com/en/graphql/reference/enums#securityadvisoryecosystem
-var githubEcosystems = map[string]FindingEcosystemType{
-	"ACTIONS":  FindingEcosystemGHA,
-	"COMPOSER": FindingEcosystemPHP,
-	"ERLANG":   FindingEcosystemErlang,
-	"GO":       FindingEcosystemGo,
-	"MAVEN":    FindingEcosystemJava,
-	"NPM":      FindingEcosystemJS,
-	"NUGET":    FindingEcosystemCSharp,
-	"PIP":      FindingEcosystemPython,
-	"PUB":      FindingEcosystemDart,
-	"RUBYGEMS": FindingEcosystemRuby,
-	"RUST":     FindingEcosystemRust,
-	"SWIFT":    FindingEcosystemSwift,
+var githubEcosystems = map[string]config.FindingEcosystemType{
+	"ACTIONS":  config.FindingEcosystemGHA,
+	"COMPOSER": config.FindingEcosystemPHP,
+	"ERLANG":   config.FindingEcosystemErlang,
+	"GO":       config.FindingEcosystemGo,
+	"MAVEN":    config.FindingEcosystemJava,
+	"NPM":      config.FindingEcosystemJS,
+	"NUGET":    config.FindingEcosystemCSharp,
+	"PIP":      config.FindingEcosystemPython,
+	"PUB":      config.FindingEcosystemDart,
+	"RUBYGEMS": config.FindingEcosystemRuby,
+	"RUST":     config.FindingEcosystemRust,
+	"SWIFT":    config.FindingEcosystemSwift,
 }
 
 func (gh *GithubDataSource) CollectFindings(projects *ProjectCollection, wg *sync.WaitGroup) error {

--- a/querying/github_test.go
+++ b/querying/github_test.go
@@ -56,8 +56,8 @@ func TestCollectFindingsSingleProjectSingleFinding(t *testing.T) {
 				},
 				Findings: []*querying.Finding{
 					{
-						Ecosystem:   querying.FindingEcosystemGo,
-						Severity:    querying.FindingSeverityCritical,
+						Ecosystem:   config.FindingEcosystemGo,
+						Severity:    config.FindingSeverityCritical,
 						Description: "The Improbability Drive is far too improbable.",
 						PackageName: "improbability-drive",
 						Identifiers: querying.FindingIdentifierMap{
@@ -116,8 +116,8 @@ func TestCollectFindingsOwnerNotConfigured(t *testing.T) {
 				},
 				Findings: []*querying.Finding{
 					{
-						Ecosystem:   querying.FindingEcosystemGo,
-						Severity:    querying.FindingSeverityCritical,
+						Ecosystem:   config.FindingEcosystemGo,
+						Severity:    config.FindingSeverityCritical,
 						Description: "The Improbability Drive is far too improbable.",
 						PackageName: "improbability-drive",
 						Identifiers: querying.FindingIdentifierMap{
@@ -180,8 +180,8 @@ func TestCollectFindingsOwnerIsConfigured(t *testing.T) {
 				},
 				Findings: []*querying.Finding{
 					{
-						Ecosystem:   querying.FindingEcosystemGo,
-						Severity:    querying.FindingSeverityCritical,
+						Ecosystem:   config.FindingEcosystemGo,
+						Severity:    config.FindingSeverityCritical,
 						Description: "The Improbability Drive is far too improbable.",
 						PackageName: "improbability-drive",
 						Identifiers: querying.FindingIdentifierMap{


### PR DESCRIPTION
This is a preemptive move to prevent import cycles necessary for integrating multiple datasources. I started down that path first, and quickly realized this was necessary first.

This also makes a lot more sense, I think, since we will eventually have a lot of ecosystem and severity-related config.