### PR TITLE
feat: Combine all configuration from CLI, env, and file into a single viper config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ func Execute() {
 
 func init() {
 	persistent := rootCmd.PersistentFlags()
-	persistent.BoolP("disable-slack", "d", false, "Disable Slack alerts.")
+	persistent.BoolP("disable_slack", "d", false, "Disable Slack alerts.")
 
 	persistent.StringP("config", "c", "config.toml", "Config file path.")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"path/filepath"
-
 	"github.com/rs/zerolog"
-	"github.com/underdog-tech/vulnbot/internal"
 	"github.com/underdog-tech/vulnbot/logger"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -50,10 +48,11 @@ func init() {
 	persistent := rootCmd.PersistentFlags()
 	persistent.BoolP("disable-slack", "d", false, "Disable Slack alerts.")
 
-	projectRootDir := internal.GetProjectRootDir()
-	persistent.StringP("config", "c", filepath.Join(projectRootDir, "config.toml"), "Config file path.")
+	persistent.StringP("config", "c", "config.toml", "Config file path.")
 
 	persistent.BoolP("quiet", "q", false, "Suppress all console output. (Mutually exclusive with 'verbose'.)")
 	persistent.CountP("verbose", "v", "More verbose output. Specifying multiple times increases verbosity. (Mutually exclusive with 'quiet'.)")
+
+	viper.BindPFlags(persistent)
 	rootCmd.MarkFlagsMutuallyExclusive("verbose", "quiet")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,6 @@ func init() {
 	persistent.BoolP("quiet", "q", false, "Suppress all console output. (Mutually exclusive with 'verbose'.)")
 	persistent.CountP("verbose", "v", "More verbose output. Specifying multiple times increases verbosity. (Mutually exclusive with 'quiet'.)")
 
-	viper.BindPFlags(persistent)
+	_ = viper.BindPFlags(persistent)
 	rootCmd.MarkFlagsMutuallyExclusive("verbose", "quiet")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/underdog-tech/vulnbot/logger"
@@ -85,61 +84,6 @@ func GetUserConfig(configFile string) (Config, error) {
 	viper.Unmarshal(&userCfg)
 
 	return userCfg, nil
-}
-
-func LoadConfig(params ViperParams) error {
-	log := logger.Get()
-
-	v := getViper()
-
-	filename := filepath.Base(*params.ConfigPath)
-	extension := filepath.Ext(*params.ConfigPath)
-	configDir := filepath.Dir(*params.ConfigPath)
-
-	v.SetConfigName(filename)
-	v.AddConfigPath(configDir)
-	v.SetConfigType(strings.TrimLeft(extension, "."))
-
-	err := v.ReadInConfig()
-	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to read config.")
-		return err
-	}
-
-	err = v.Unmarshal(&params.Output)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to unmarshal config.")
-		return err
-	}
-
-	log.Debug().Any("config", params.Output).Msg("Config loaded.")
-	return nil
-}
-
-func LoadEnv(params ViperParams) error {
-	log := logger.Get()
-
-	v := getViper()
-
-	// Read in environment variables that match
-	v.SetConfigFile(*params.EnvFileName)
-	v.SetConfigType("env")
-	v.AutomaticEnv()
-
-	err := v.ReadInConfig()
-	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to read ENV file.")
-		return err
-	}
-
-	err = v.Unmarshal(&params.Output)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to unmarshal ENV.")
-		return err
-	}
-
-	log.Debug().Any("env", params.Output).Msg("ENV loaded.")
-	return nil
 }
 
 func GetIconForSeverity(severity FindingSeverityType, severities []SeverityConfig) (string, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -79,7 +79,7 @@ func GetUserConfig(configFile string) (Config, error) {
 	viper.AutomaticEnv()
 
 	// Finally, copy all loaded values into the config object
-	viper.Unmarshal(&userCfg)
+	_ = viper.Unmarshal(&userCfg)
 
 	return userCfg, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"reflect"
 	"strings"
 
 	"github.com/underdog-tech/vulnbot/logger"
@@ -28,10 +30,47 @@ type Config struct {
 	Team                  []TeamConfig
 }
 
+func fileExists(fname string) bool {
+	if _, err := os.Stat(fname); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
+}
+
 func GetUserConfig(configFile string) (Config, error) {
 	log := logger.Get()
 
 	userCfg := Config{}
+
+	// Use reflection to register all config fields in Viper to set up defaults
+	cfgFields := reflect.ValueOf(userCfg)
+	cfgType := cfgFields.Type()
+
+	for i := 0; i < cfgFields.NumField(); i++ {
+		viper.SetDefault(cfgType.Field(i).Name, cfgFields.Field(i).Interface())
+	}
+
+	// Load the main config file
+	if !fileExists(configFile) {
+		log.Fatal().Str("config", configFile).Msg("Config file not found.")
+	}
+	viper.SetConfigFile(configFile)
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatal().Err(err).Msg("Error reading config file.")
+	}
+
+	// (Optionally) Load a .env file
+	if fileExists("./.env") {
+		viper.SetConfigFile("./.env")
+		viper.SetConfigType("env")
+		if err := viper.ReadInConfig(); err != nil {
+			log.Error().Err(err).Msg("Error loading .env file.")
+		}
+	} else {
+		log.Warn().Msg("No .env file found; not loaded.")
+	}
 
 	// Set up env var overrides
 	replacer := strings.NewReplacer("-", "_")
@@ -39,27 +78,7 @@ func GetUserConfig(configFile string) (Config, error) {
 	viper.SetEnvPrefix("vulnbot")
 	viper.AutomaticEnv()
 
-	// Load the main config file
-	viper.SetConfigFile(configFile)
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			log.Fatal().Str("config", configFile).Err(err).Msg("Config file not found.")
-		} else {
-			log.Fatal().Err(err).Msg("Error reading config file.")
-		}
-	}
-	viper.Unmarshal(&userCfg)
-
-	// (Optionally) Load a .env file
-	viper.SetConfigFile("./.env")
-	viper.SetConfigType("env")
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			log.Warn().Msg("No .env file found; not loaded.")
-		} else {
-			log.Error().Err(err).Msg("Error loading .env file.")
-		}
-	}
+	// Finally, copy all loaded values into the config object
 	viper.Unmarshal(&userCfg)
 
 	return userCfg, nil

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type TeamConfig struct {
 
 type Config struct {
 	Default_slack_channel string
+	Disable_slack         bool
 	Github_org            string
 	Slack_auth_token      string
 	Github_token          string

--- a/config/config.go
+++ b/config/config.go
@@ -28,27 +28,6 @@ type Config struct {
 	Team                  []TeamConfig
 }
 
-type Env struct {
-	GithubOrg      string `mapstructure:"GITHUB_ORG"`
-	SlackAuthToken string `mapstructure:"SLACK_AUTH_TOKEN"`
-	GithubToken    string `mapstructure:"GITHUB_TOKEN"`
-}
-
-var viperClient *viper.Viper
-
-type ViperParams struct {
-	ConfigPath  *string
-	Output      interface{}
-	EnvFileName *string
-}
-
-func getViper() *viper.Viper {
-	if viperClient == nil {
-		viperClient = viper.New()
-	}
-	return viperClient
-}
-
 func GetUserConfig(configFile string) (Config, error) {
 	log := logger.Get()
 

--- a/internal/datasources.go
+++ b/internal/datasources.go
@@ -8,11 +8,11 @@ import (
 	"github.com/underdog-tech/vulnbot/querying"
 )
 
-func GetDataSources(env config.Env, cfg config.Config) []querying.DataSource {
+func GetDataSources(cfg *config.Config) []querying.DataSource {
 	dataSources := []querying.DataSource{}
 
-	if env.GithubToken != "" {
-		ghds := querying.NewGithubDataSource(cfg, env)
+	if cfg.Github_token != "" {
+		ghds := querying.NewGithubDataSource(cfg)
 		dataSources = append(dataSources, &ghds)
 	}
 

--- a/internal/scan.go
+++ b/internal/scan.go
@@ -20,7 +20,7 @@ func Scan(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to load configuration.")
 	}
-	log.Trace().Any("viperConfig", &cfg).Msg("Unified Viper config")
+	log.Trace().Msg("Loaded unified Viper config")
 
 	// Load and query all configured data sources
 	dataSources := GetDataSources(&cfg)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -17,13 +17,6 @@ func checkErr(err error) {
 	}
 }
 
-// getBool return the bool value of a flag with the given name
-func getBool(flags *pflag.FlagSet, flag string) bool {
-	b, err := flags.GetBool(flag)
-	checkErr(err)
-	return b
-}
-
 // getString return the string value of a flag with the given name
 func getString(flags *pflag.FlagSet, flag string) string {
 	s, err := flags.GetString(flag)

--- a/querying/github.go
+++ b/querying/github.go
@@ -18,20 +18,20 @@ type githubClient interface {
 type GithubDataSource struct {
 	GhClient githubClient
 	orgName  string
-	conf     config.Config
+	conf     *config.Config
 	ctx      context.Context
 }
 
-func NewGithubDataSource(conf config.Config, env config.Env) GithubDataSource {
+func NewGithubDataSource(conf *config.Config) GithubDataSource {
 	ghTokenSource := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: env.GithubToken},
+		&oauth2.Token{AccessToken: conf.Github_token},
 	)
 	httpClient := oauth2.NewClient(context.Background(), ghTokenSource)
 	ghClient := githubv4.NewClient(httpClient)
 
 	return GithubDataSource{
 		GhClient: ghClient,
-		orgName:  env.GithubOrg,
+		orgName:  conf.Github_org,
 		conf:     conf,
 		ctx:      context.Background(),
 	}

--- a/querying/github_test.go
+++ b/querying/github_test.go
@@ -65,11 +65,10 @@ func TestCollectFindingsSingleProjectSingleFinding(t *testing.T) {
 	defer server.Close()
 
 	conf := config.Config{}
-	env := config.Env{}
-	env.GithubOrg = "heart-of-gold"
-	env.GithubToken = "pangalactic-gargleblaster"
+	conf.Github_org = "heart-of-gold"
+	conf.Github_token = "pangalactic-gargleblaster"
 
-	ds := querying.NewGithubDataSource(conf, env)
+	ds := querying.NewGithubDataSource(&conf)
 	ds.GhClient = githubv4.NewEnterpriseClient(server.URL, &http.Client{})
 
 	projects := querying.NewProjectCollection()
@@ -95,11 +94,10 @@ func TestCollectFindingsOwnerNotConfigured(t *testing.T) {
 	defer server.Close()
 
 	conf := config.Config{}
-	env := config.Env{}
-	env.GithubOrg = "heart-of-gold"
-	env.GithubToken = "pangalactic-gargleblaster"
+	conf.Github_org = "heart-of-gold"
+	conf.Github_token = "pangalactic-gargleblaster"
 
-	ds := querying.NewGithubDataSource(conf, env)
+	ds := querying.NewGithubDataSource(&conf)
 	ds.GhClient = githubv4.NewEnterpriseClient(server.URL, &http.Client{})
 
 	projects := querying.NewProjectCollection()
@@ -127,11 +125,10 @@ func TestCollectFindingsOwnerIsConfigured(t *testing.T) {
 	conf := config.Config{
 		Team: []config.TeamConfig{crewTeam},
 	}
-	env := config.Env{}
-	env.GithubOrg = "heart-of-gold"
-	env.GithubToken = "pangalactic-gargleblaster"
+	conf.Github_org = "heart-of-gold"
+	conf.Github_token = "pangalactic-gargleblaster"
 
-	ds := querying.NewGithubDataSource(conf, env)
+	ds := querying.NewGithubDataSource(&conf)
 	ds.GhClient = githubv4.NewEnterpriseClient(server.URL, &http.Client{})
 
 	projects := querying.NewProjectCollection()
@@ -156,11 +153,10 @@ func TestCollectFindingsMultipleFindings(t *testing.T) {
 	defer server.Close()
 
 	conf := config.Config{}
-	env := config.Env{}
-	env.GithubOrg = "heart-of-gold"
-	env.GithubToken = "pangalactic-gargleblaster"
+	conf.Github_org = "heart-of-gold"
+	conf.Github_token = "pangalactic-gargleblaster"
 
-	ds := querying.NewGithubDataSource(conf, env)
+	ds := querying.NewGithubDataSource(&conf)
 	ds.GhClient = githubv4.NewEnterpriseClient(server.URL, &http.Client{})
 
 	projects := querying.NewProjectCollection()

--- a/reporting/console.go
+++ b/reporting/console.go
@@ -14,7 +14,7 @@ import (
 )
 
 type ConsoleReporter struct {
-	Config config.Config
+	Config *config.Config
 }
 
 // SendSummaryReport generates a brief report summarizing all the discovered

--- a/reporting/console_test.go
+++ b/reporting/console_test.go
@@ -1,4 +1,4 @@
-package reporting
+package reporting_test
 
 import (
 	"fmt"
@@ -10,6 +10,7 @@ import (
 	"github.com/gookit/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/underdog-tech/vulnbot/config"
+	"github.com/underdog-tech/vulnbot/reporting"
 )
 
 func TestSendConsoleSummaryReport(t *testing.T) {
@@ -17,8 +18,8 @@ func TestSendConsoleSummaryReport(t *testing.T) {
 	reader, writer, _ := os.Pipe()
 	os.Stdout = writer
 
-	reporter := ConsoleReporter{Config: config.Config{}}
-	report := NewFindingSummary()
+	reporter := reporting.ConsoleReporter{Config: &config.Config{}}
+	report := reporting.NewFindingSummary()
 	report.AffectedRepos = 2
 	report.TotalCount = 42
 	report.VulnsByEcosystem[config.FindingEcosystemPython] = 2

--- a/reporting/slack.go
+++ b/reporting/slack.go
@@ -17,7 +17,7 @@ import (
 )
 
 type SlackReporter struct {
-	Config config.Config
+	Config *config.Config
 	client SlackClientInterface
 }
 
@@ -248,10 +248,10 @@ func (s *SlackReporter) sendSlackMessage(channel string, message slack.MsgOption
 }
 
 // NewSlackReporter returns a new SlackReporter instance for reporting out findings to a Slack server
-func NewSlackReporter(config config.Config, slackToken string) (SlackReporter, error) {
-	if slackToken == "" {
+func NewSlackReporter(cfg *config.Config) (SlackReporter, error) {
+	if cfg.Slack_auth_token == "" {
 		return SlackReporter{}, fmt.Errorf("No Slack token was provided.")
 	}
-	client := slack.New(slackToken, slack.OptionDebug(true))
-	return SlackReporter{Config: config, client: client}, nil
+	client := slack.New(cfg.Slack_auth_token, slack.OptionDebug(true))
+	return SlackReporter{Config: cfg, client: client}, nil
 }


### PR DESCRIPTION
This change pulls all of the configuration methods/variables into a single combined configuration object. This makes it easier to keep track of options, and also allows us to work toward parity between env/cli/file config. So for example when we implement #50, we will only have to check a single config option.

This checklist should represent the full path to completing this change:

* [X] Pull CLI into combined viper config
* [X] Pull env vars into combined viper config
* [X] Pull config file into combined viper config
* [X] Use new combined viper config everywhere
* [ ] ~~Figure out the chicken/egg problem with logging verbosity -- do we need to load config twice?~~ I think it makes sense to get this PR landed rather than hold up for this, since this keeps parity with current functionality. We can add a bug report to follow up on this particular item.
* [x] Update tests