### PR TITLE
feat: Display project links in the Slack team reports

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -8,3 +8,6 @@ enable = [
     "prealloc",
     "zerologlint",
 ]
+
+[linters-settings.cyclop]
+max-complexity = 11

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/rs/zerolog"
-	"github.com/underdog-tech/vulnbot/config"
 	"github.com/underdog-tech/vulnbot/logger"
 
 	"github.com/spf13/cobra"
@@ -47,7 +46,9 @@ func NewRootCommand() *cobra.Command {
 
 	// Set up Viper config
 	_ = viper.BindPFlags(pflags)
-	config.SetConfigDefaults()
+	// tarkatronic(2023-11-07): This appears to be no longer necessary.
+	// Leaving it commented out for the time being. Viper is confusing.
+	// config.SetConfigDefaults()
 
 	return rootCmd
 }

--- a/querying/github.go
+++ b/querying/github.go
@@ -146,7 +146,11 @@ func (gh *GithubDataSource) CollectFindings(projects *ProjectCollection, wg *syn
 func (gh *GithubDataSource) processRepoFindings(projects *ProjectCollection, repo orgRepo) error {
 	log := logger.Get()
 	project := projects.GetProject(repo.Name)
-	project.Links["GitHub"] = repo.Url
+
+	// Link directly to Dependabot findings.
+	// There doesn't appear to be a GraphQL property for this link.
+	project.Links["GitHub"] = repo.Url + "/security/dependabot"
+
 	log.Debug().Str("project", project.Name).Msg("Processing findings for project.")
 
 	for _, vuln := range repo.VulnerabilityAlerts.Nodes {

--- a/querying/github_test.go
+++ b/querying/github_test.go
@@ -38,7 +38,7 @@ func getTestProject() querying.ProjectCollection {
 			{
 				Name: "zaphod",
 				Links: map[string]string{
-					"GitHub": "https://heart-of-gold/zaphod",
+					"GitHub": "https://heart-of-gold/zaphod/security/dependabot",
 				},
 				Findings: []*querying.Finding{
 					{

--- a/reporting/slack.go
+++ b/reporting/slack.go
@@ -148,8 +148,16 @@ func (s *SlackReporter) BuildTeamRepositoryReport(
 			severityIcon = DEFAULT_SLACK_ICON
 		}
 	}
+	projLinks := make([]string, 0)
+	for title, link := range repoReport.Project.Links {
+		projLinks = append(projLinks, fmt.Sprintf("[<%s|%s>]", link, title))
+	}
+	projName := fmt.Sprintf("%s *%s*", severityIcon, repoReport.Project.Name)
+	if len(projLinks) > 0 {
+		projName = fmt.Sprintf("%s · %s", projName, strings.Join(projLinks, " "))
+	}
 	fields := []*slack.TextBlockObject{
-		slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("%s *%s*", severityIcon, repoReport.Project.Name), false, false),
+		slack.NewTextBlockObject(slack.MarkdownType, projName, false, false),
 		slack.NewTextBlockObject(slack.MarkdownType, strings.Join(vulnCounts, " | "), false, false),
 	}
 	return slack.NewSectionBlock(nil, fields, nil)

--- a/reporting/slack.go
+++ b/reporting/slack.go
@@ -149,7 +149,7 @@ func (s *SlackReporter) BuildTeamRepositoryReport(
 		}
 	}
 	fields := []*slack.TextBlockObject{
-		slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("%s *%s*", severityIcon, repoReport.Name), false, false),
+		slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("%s *%s*", severityIcon, repoReport.Project.Name), false, false),
 		slack.NewTextBlockObject(slack.MarkdownType, strings.Join(vulnCounts, " | "), false, false),
 	}
 	return slack.NewSectionBlock(nil, fields, nil)
@@ -172,7 +172,7 @@ func (s *SlackReporter) BuildTeamReport(
 	sort.Sort(repos)
 	var summaryReport *ProjectFindingSummary
 	for _, repo := range repos {
-		if repo.Name == SUMMARY_KEY {
+		if repo.Project.Name == SUMMARY_KEY {
 			summaryReport = repo
 			continue
 		}

--- a/reporting/slack_test.go
+++ b/reporting/slack_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/underdog-tech/vulnbot/config"
+	"github.com/underdog-tech/vulnbot/querying"
 	"github.com/underdog-tech/vulnbot/reporting"
 )
 
@@ -206,7 +207,7 @@ func TestSendSlackSummaryReportSendsSingleMessage(t *testing.T) {
 func TestBuildSlackTeamRepositoryReport(t *testing.T) {
 	reporter := reporting.SlackReporter{Config: &config.Config{}}
 
-	report := reporting.NewProjectFindingSummary("foo")
+	report := reporting.NewProjectFindingSummary(querying.NewProject("foo"))
 	report.VulnsByEcosystem[config.FindingEcosystemPython] = 15
 	report.VulnsBySeverity[config.FindingSeverityCritical] = 2
 	report.VulnsBySeverity[config.FindingSeverityHigh] = 3
@@ -240,16 +241,16 @@ func TestBuildSlackTeamReport(t *testing.T) {
 	}
 	reporter := reporting.SlackReporter{Config: &cfg}
 
-	repo1Report := reporting.NewProjectFindingSummary("repo1")
+	repo1Report := reporting.NewProjectFindingSummary(querying.NewProject("repo1"))
 	repo1Report.VulnsByEcosystem[config.FindingEcosystemPython] = 10
 	repo1Report.VulnsBySeverity[config.FindingSeverityLow] = 10
 
-	repo2Report := reporting.NewProjectFindingSummary("repo2")
+	repo2Report := reporting.NewProjectFindingSummary(querying.NewProject("repo2"))
 	repo2Report.VulnsByEcosystem[config.FindingEcosystemPython] = 5
 	repo2Report.VulnsBySeverity[config.FindingSeverityCritical] = 1
 	repo2Report.VulnsBySeverity[config.FindingSeverityModerate] = 4
 
-	summaryReport := reporting.NewProjectFindingSummary(reporting.SUMMARY_KEY)
+	summaryReport := reporting.NewProjectFindingSummary(querying.NewProject(reporting.SUMMARY_KEY))
 	summaryReport.AffectedRepos = 2
 	summaryReport.TotalCount = 15
 
@@ -336,9 +337,9 @@ func TestSendSlackTeamReportsSendsMessagePerTeam(t *testing.T) {
 	}
 	mockClient := new(MockSlackClient)
 	reporter := reporting.SlackReporter{Config: &cfg, Client: mockClient}
-	repo1Report := reporting.NewProjectFindingSummary("repo1")
-	repo2Report := reporting.NewProjectFindingSummary("repo2")
-	summaryReport := reporting.NewProjectFindingSummary(reporting.SUMMARY_KEY)
+	repo1Report := reporting.NewProjectFindingSummary(querying.NewProject("repo1"))
+	repo2Report := reporting.NewProjectFindingSummary(querying.NewProject("repo2"))
+	summaryReport := reporting.NewProjectFindingSummary(querying.NewProject(reporting.SUMMARY_KEY))
 	teamReports := map[config.TeamConfig]reporting.TeamProjectCollection{
 		teamFoo: {
 			&repo1Report,

--- a/reporting/slack_test.go
+++ b/reporting/slack_test.go
@@ -206,8 +206,11 @@ func TestSendSlackSummaryReportSendsSingleMessage(t *testing.T) {
 
 func TestBuildSlackTeamRepositoryReport(t *testing.T) {
 	reporter := reporting.SlackReporter{Config: &config.Config{}}
-
-	report := reporting.NewProjectFindingSummary(querying.NewProject("foo"))
+	proj := querying.NewProject("foo")
+	proj.Links = map[string]string{
+		"GitHub": "https://github.com/bar/foo",
+	}
+	report := reporting.NewProjectFindingSummary(proj)
 	report.VulnsByEcosystem[config.FindingEcosystemPython] = 15
 	report.VulnsBySeverity[config.FindingSeverityCritical] = 2
 	report.VulnsBySeverity[config.FindingSeverityHigh] = 3
@@ -218,7 +221,7 @@ func TestBuildSlackTeamRepositoryReport(t *testing.T) {
 		"fields": []map[string]interface{}{
 			{
 				"type": "mrkdwn",
-				"text": "  *foo*",
+				"text": "  *foo* · [<https://github.com/bar/foo|GitHub>]",
 			},
 			{
 				"type": "mrkdwn",

--- a/reporting/summary.go
+++ b/reporting/summary.go
@@ -50,7 +50,7 @@ type FindingSummary struct {
 type ProjectFindingSummary struct {
 	FindingSummary
 
-	Name string
+	Project *querying.Project
 }
 
 // GetHighestCriticality looks for the severity level of the most critical
@@ -75,9 +75,9 @@ func NewFindingSummary() FindingSummary {
 	}
 }
 
-func NewProjectFindingSummary(name string) ProjectFindingSummary {
+func NewProjectFindingSummary(project *querying.Project) ProjectFindingSummary {
 	summary := NewFindingSummary()
-	return ProjectFindingSummary{Name: name, FindingSummary: summary}
+	return ProjectFindingSummary{Project: project, FindingSummary: summary}
 }
 
 func SummarizeFindings(projects *querying.ProjectCollection) (FindingSummary, []ProjectFindingSummary) {
@@ -86,7 +86,7 @@ func SummarizeFindings(projects *querying.ProjectCollection) (FindingSummary, []
 	projectReportCollection := []ProjectFindingSummary{}
 
 	for _, project := range projects.Projects {
-		projectReport := NewProjectFindingSummary(project.Name)
+		projectReport := NewProjectFindingSummary(project)
 		if numFindings := len(project.Findings); numFindings > 0 {
 			affectedRepos += 1
 			vulnCount += numFindings
@@ -129,7 +129,7 @@ func (r TeamProjectCollection) Less(i, j int) bool {
 	if sevOne != sevTwo {
 		return sevOne < sevTwo
 	}
-	return r[i].Name < r[j].Name
+	return r[i].Project.Name < r[j].Project.Name
 }
 
 // GroupTeamFindings gathers a map of each team and the summaries of the projects
@@ -140,7 +140,7 @@ func GroupTeamFindings(projects *querying.ProjectCollection, summaries []Project
 	for _, project := range projects.Projects {
 		projectSummary := ProjectFindingSummary{}
 		for _, sum := range summaries {
-			if sum.Name == project.Name {
+			if sum.Project == project {
 				projectSummary = sum
 				break
 			}
@@ -152,7 +152,7 @@ func GroupTeamFindings(projects *querying.ProjectCollection, summaries []Project
 	}
 	// We also need a summary report for each team
 	for team, projects := range teamProjects {
-		summaryReport := NewProjectFindingSummary(SUMMARY_KEY)
+		summaryReport := NewProjectFindingSummary(querying.NewProject(SUMMARY_KEY))
 		for _, project := range projects {
 			summaryReport.TotalCount += project.TotalCount
 		}


### PR DESCRIPTION
Team Slack reports now look like this:
<img width="583" alt="Screenshot 2023-11-07 at 5 12 47 PM" src="https://github.com/underdog-tech/vulnbot/assets/37809/8c2b3f11-4c42-4975-aa7a-56cb4507f5fa">

🙌🏻 

The links go straight to the Dependabot findings pages for the applicable project(s).

Plus, as other data sources are implemented, those links will also be automagically added!

This also includes a fix to filter out archived and forked repositories from the ownership query, which was causing them to still show up in reports.