### PR TITLE
fix get team by slug bug

### DIFF
--- a/querying/codeql.go
+++ b/querying/codeql.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/google/go-github/v84/github"
+	"github.com/rs/zerolog"
 
 	"github.com/underdog-tech/vulnbot/configs"
 	"github.com/underdog-tech/vulnbot/logger"
@@ -60,11 +61,7 @@ func (cql *CodeQLDataSource) CollectFindings(projects *ProjectCollection, wg *sy
 	log := logger.Get()
 	defer wg.Done()
 
-	repoNameToTeamConfig, err := cql.getRepoNameToTeamConfig()
-	if err != nil {
-		log.Error().Err(err).Msg("GitHub list repos by slug request failed!")
-		return err
-	}
+	repoNameToTeamConfig := cql.getRepoNameToTeamConfig(log)
 
 	iter := cql.GhClient.ListAlertsForOrgIter(
 		cql.ctx,
@@ -114,16 +111,17 @@ func (cql *CodeQLDataSource) processFinding(alert *github.Alert) (*Finding, erro
 }
 
 // Maps repository names to their corresponding team configs based on the GH team slug.
-func (cql *CodeQLDataSource) getRepoNameToTeamConfig() (map[string]configs.TeamConfig, error) {
+func (cql *CodeQLDataSource) getRepoNameToTeamConfig(log zerolog.Logger) map[string]configs.TeamConfig {
 	repoNameToTeamConfig := make(map[string]configs.TeamConfig)
 	for _, team := range cql.conf.Team {
 		slugIter := cql.GhClient.ListTeamReposBySlugIter(cql.ctx, cql.orgName, team.Github_slug, nil)
 		for repo, err := range slugIter {
 			if err != nil {
-				return repoNameToTeamConfig, err
+				log.Error().Err(err).Str("team_name", team.Name).Msg("Failed to find owned repos for team")
+			} else {
+				repoNameToTeamConfig[*repo.Name] = team
 			}
-			repoNameToTeamConfig[*repo.Name] = team
 		}
 	}
-	return repoNameToTeamConfig, nil
+	return repoNameToTeamConfig
 }

--- a/querying/codeql_test.go
+++ b/querying/codeql_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/underdog-tech/vulnbot/configs"
+	"github.com/underdog-tech/vulnbot/logger"
 )
 
 const (
@@ -141,6 +142,7 @@ func TestProcessFinding(t *testing.T) {
 }
 
 func TestGetRepoNameToTeamConfig(t *testing.T) {
+	testLogger := logger.Get()
 	mockRepo := "link"
 	mockTeam := getMockTeam()
 	conf := &configs.Config{
@@ -163,12 +165,11 @@ func TestGetRepoNameToTeamConfig(t *testing.T) {
 		maps.All(mockRepoMap),
 	)
 
-	actualRepoNameToTeamConfig, err := cql.getRepoNameToTeamConfig()
+	actualRepoNameToTeamConfig := cql.getRepoNameToTeamConfig(testLogger)
 
 	expectedRepoNameToTeamConfig := map[string]configs.TeamConfig{
 		mockRepo: mockTeam,
 	}
-	assert.NoError(t, err)
 	assert.Equal(t, expectedRepoNameToTeamConfig, actualRepoNameToTeamConfig)
 
 	mockClient.AssertExpectations(t)


### PR DESCRIPTION
Got the following error when vulnbot ran:
```
2026-03-09T13:28:04Z ERR GitHub list repos by slug request failed! error="GET https://api.github.com/orgs/underdog-tech/teams/infosec/repos: 404 Not Found []" go_version=go1.25.7
```

This prevented the other CodeQL checks from running. 

Add handling to skip an iteration and log the error if no owned repos are found for a given team instead of erroring out the datasource.