### PR TITLE
fix: CodeQL team ownership attribution

### DIFF
--- a/querying/codeql.go
+++ b/querying/codeql.go
@@ -124,6 +124,14 @@ func (cql *CodeQLDataSource) getRepoNameToTeamConfigs(log zerolog.Logger) map[st
 				log.Error().Err(err).Str("team_name", team.Name).Msg("Failed to find owned repos for team")
 				continue
 			}
+			if shouldIgnoreRepository(repo.GetArchived(), repo.GetFork(), repo.Topics) {
+				log.Debug().
+					Str("repository", repo.GetName()).
+					Bool("is_fork", repo.GetFork()).
+					Bool("is_archived", repo.GetArchived()).
+					Msg("Skipping untracked repository.")
+				continue
+			}
 			if repo.Permissions == nil || (!repo.Permissions.GetAdmin() && !repo.Permissions.GetMaintain()) {
 				continue
 			}

--- a/querying/codeql.go
+++ b/querying/codeql.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"sync"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/google/go-github/v84/github"
 	"github.com/rs/zerolog"
 
@@ -61,7 +62,7 @@ func (cql *CodeQLDataSource) CollectFindings(projects *ProjectCollection, wg *sy
 	log := logger.Get()
 	defer wg.Done()
 
-	repoNameToTeamConfig := cql.getRepoNameToTeamConfig(log)
+	repoNameToTeamConfigs := cql.getRepoNameToTeamConfigs(log)
 
 	iter := cql.GhClient.ListAlertsForOrgIter(
 		cql.ctx,
@@ -85,12 +86,15 @@ func (cql *CodeQLDataSource) CollectFindings(projects *ProjectCollection, wg *sy
 		project.Findings = append(project.Findings, finding)
 		project.Link = fmt.Sprintf("%s/%s", *alert.Repository.HTMLURL, "security")
 
-		team, ok := repoNameToTeamConfig[*alert.Repository.Name]
+		teams, ok := repoNameToTeamConfigs[*alert.Repository.Name]
 		if !ok {
-			log.Warn().Err(err).Str("repository", *alert.Repository.Name).Msg("Failed to find team config in repository team map")
+			log.Warn().Str("repository", *alert.Repository.Name).Msg("Failed to find team config in repository team map")
 			continue
 		}
-		project.Owners.Add(team)
+		teamIter := teams.Iterator()
+		for team := range teamIter.C {
+			project.Owners.Add(team)
+		}
 	}
 
 	return nil
@@ -110,18 +114,24 @@ func (cql *CodeQLDataSource) processFinding(alert *github.Alert) (*Finding, erro
 	}, nil
 }
 
-// Maps repository names to their corresponding team configs based on the GH team slug.
-func (cql *CodeQLDataSource) getRepoNameToTeamConfig(log zerolog.Logger) map[string]configs.TeamConfig {
-	repoNameToTeamConfig := make(map[string]configs.TeamConfig)
+// Maps repository names to all configured teams with administrative or maintenance access.
+func (cql *CodeQLDataSource) getRepoNameToTeamConfigs(log zerolog.Logger) map[string]mapset.Set[configs.TeamConfig] {
+	repoNameToTeamConfigs := make(map[string]mapset.Set[configs.TeamConfig])
 	for _, team := range cql.conf.Team {
 		slugIter := cql.GhClient.ListTeamReposBySlugIter(cql.ctx, cql.orgName, team.Github_slug, nil)
 		for repo, err := range slugIter {
 			if err != nil {
 				log.Error().Err(err).Str("team_name", team.Name).Msg("Failed to find owned repos for team")
-			} else {
-				repoNameToTeamConfig[*repo.Name] = team
+				continue
 			}
+			if repo.Permissions == nil || (!repo.Permissions.GetAdmin() && !repo.Permissions.GetMaintain()) {
+				continue
+			}
+			if _, ok := repoNameToTeamConfigs[repo.GetName()]; !ok {
+				repoNameToTeamConfigs[repo.GetName()] = mapset.NewSet[configs.TeamConfig]()
+			}
+			repoNameToTeamConfigs[repo.GetName()].Add(team)
 		}
 	}
-	return repoNameToTeamConfig
+	return repoNameToTeamConfigs
 }

--- a/querying/codeql_test.go
+++ b/querying/codeql_test.go
@@ -199,3 +199,71 @@ func TestGetRepoNameToTeamConfigs(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRepoNameToTeamConfigsExcludesUntrackedRepositories(t *testing.T) {
+	team := getMockTeam()
+	testContext := context.Background()
+	adminPermissions := &github.RepositoryPermissions{Admin: github.Ptr(true)}
+
+	tests := map[string]struct {
+		repository *github.Repository
+		excluded   bool
+	}{
+		"active repository": {
+			repository: &github.Repository{
+				Name:        github.Ptr("active"),
+				Permissions: adminPermissions,
+			},
+		},
+		"archived repository": {
+			repository: &github.Repository{
+				Name:        github.Ptr("archived"),
+				Archived:    github.Ptr(true),
+				Permissions: adminPermissions,
+			},
+			excluded: true,
+		},
+		"forked repository": {
+			repository: &github.Repository{
+				Name:        github.Ptr("forked"),
+				Fork:        github.Ptr(true),
+				Permissions: adminPermissions,
+			},
+			excluded: true,
+		},
+		"disabled by topic": {
+			repository: &github.Repository{
+				Name:        github.Ptr("disabled"),
+				Topics:      []string{"prefix-DiSaBlE-VuLnBoT-suffix"},
+				Permissions: adminPermissions,
+			},
+			excluded: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockClient := &MockClient{}
+			cql := &CodeQLDataSource{
+				GhClient: mockClient,
+				orgName:  mockOrgName,
+				conf:     &configs.Config{Team: []configs.TeamConfig{team}},
+				ctx:      testContext,
+			}
+			mockClient.On("ListTeamReposBySlugIter", testContext, mockOrgName, team.Github_slug, nil).Return(
+				maps.All(map[*github.Repository]error{test.repository: nil}),
+			)
+
+			actual := cql.getRepoNameToTeamConfigs(logger.Get())
+
+			if test.excluded {
+				assert.Empty(t, actual)
+			} else {
+				assert.Equal(t, map[string]mapset.Set[configs.TeamConfig]{
+					test.repository.GetName(): mapset.NewSet(team),
+				}, actual)
+			}
+			mockClient.AssertExpectations(t)
+		})
+	}
+}

--- a/querying/codeql_test.go
+++ b/querying/codeql_test.go
@@ -68,15 +68,13 @@ func TestCollectFindings(t *testing.T) {
 	mockRepo := "link"
 	mockDescription := "A pretty important alert"
 
-	mockTeam := getMockTeam()
+	adminTeam := getMockTeam()
+	maintainTeam := configs.TeamConfig{Name: "Team Two", Github_slug: "team-two"}
 	conf := &configs.Config{
-		Team: []configs.TeamConfig{mockTeam},
+		Team: []configs.TeamConfig{adminTeam, maintainTeam},
 	}
 	mockClient := &MockClient{}
 	testContext := context.Background()
-	mockRepoMap := map[*github.Repository]error{
-		{Name: &mockRepo}: nil,
-	}
 	mockAlert := getMockAlert()
 	mockAlertsByOrg := map[*github.Alert]error{mockAlert: nil}
 
@@ -90,8 +88,15 @@ func TestCollectFindings(t *testing.T) {
 	mockClient.On("ListAlertsForOrgIter", testContext, mockOrgName, &github.AlertListOptions{State: Open}).Return(
 		maps.All(mockAlertsByOrg),
 	)
-	mockClient.On("ListTeamReposBySlugIter", testContext, mockOrgName, mockTeamSlug, nil).Return(
-		maps.All(mockRepoMap),
+	mockClient.On("ListTeamReposBySlugIter", testContext, mockOrgName, adminTeam.Github_slug, nil).Return(
+		maps.All(map[*github.Repository]error{
+			{Name: &mockRepo, Permissions: &github.RepositoryPermissions{Admin: github.Ptr(true)}}: nil,
+		}),
+	)
+	mockClient.On("ListTeamReposBySlugIter", testContext, mockOrgName, maintainTeam.Github_slug, nil).Return(
+		maps.All(map[*github.Repository]error{
+			{Name: &mockRepo, Permissions: &github.RepositoryPermissions{Maintain: github.Ptr(true)}}: nil,
+		}),
 	)
 
 	expectedProject := &Project{
@@ -104,7 +109,7 @@ func TestCollectFindings(t *testing.T) {
 			},
 		},
 		Link:   fmt.Sprintf("%s/%s", mockRepoUrl, mockSecurityPath),
-		Owners: mapset.NewSet(mockTeam),
+		Owners: mapset.NewSet(adminTeam, maintainTeam),
 	}
 	mockProjects := &ProjectCollection{}
 	wg := new(sync.WaitGroup)
@@ -141,36 +146,56 @@ func TestProcessFinding(t *testing.T) {
 	assert.Equal(t, expectedFinding, finding)
 }
 
-func TestGetRepoNameToTeamConfig(t *testing.T) {
+func TestGetRepoNameToTeamConfigs(t *testing.T) {
 	testLogger := logger.Get()
 	mockRepo := "link"
-	mockTeam := getMockTeam()
-	conf := &configs.Config{
-		Team: []configs.TeamConfig{mockTeam},
-	}
-	mockClient := &MockClient{}
+	adminTeam := getMockTeam()
+	maintainTeam := configs.TeamConfig{Name: "Team Two", Github_slug: "team-two"}
+	pushTeam := configs.TeamConfig{Name: "Team Three", Github_slug: "team-three"}
 	testContext := context.Background()
-	mockRepoMap := map[*github.Repository]error{
-		{Name: &mockRepo}: nil,
+
+	tests := map[string][]configs.TeamConfig{
+		"configured order":          {adminTeam, maintainTeam, pushTeam},
+		"reversed configured order": {pushTeam, maintainTeam, adminTeam},
 	}
+	for name, teams := range tests {
+		t.Run(name, func(t *testing.T) {
+			conf := &configs.Config{Team: teams}
+			mockClient := &MockClient{}
+			cql := &CodeQLDataSource{
+				GhClient: mockClient,
+				orgName:  mockOrgName,
+				conf:     conf,
+				ctx:      testContext,
+			}
 
-	cql := &CodeQLDataSource{
-		GhClient: mockClient,
-		orgName:  mockOrgName,
-		conf:     conf,
-		ctx:      testContext,
+			teamRepos := map[string]*github.Repository{
+				adminTeam.Github_slug: {
+					Name:        &mockRepo,
+					Permissions: &github.RepositoryPermissions{Admin: github.Ptr(true)},
+				},
+				maintainTeam.Github_slug: {
+					Name:        &mockRepo,
+					Permissions: &github.RepositoryPermissions{Maintain: github.Ptr(true)},
+				},
+				pushTeam.Github_slug: {
+					Name:        &mockRepo,
+					Permissions: &github.RepositoryPermissions{Push: github.Ptr(true)},
+				},
+			}
+			for _, team := range teams {
+				mockClient.On("ListTeamReposBySlugIter", testContext, mockOrgName, team.Github_slug, nil).Return(
+					maps.All(map[*github.Repository]error{teamRepos[team.Github_slug]: nil}),
+				)
+			}
+
+			actualRepoNameToTeamConfigs := cql.getRepoNameToTeamConfigs(testLogger)
+
+			expectedRepoNameToTeamConfigs := map[string]mapset.Set[configs.TeamConfig]{
+				mockRepo: mapset.NewSet(adminTeam, maintainTeam),
+			}
+			assert.Equal(t, expectedRepoNameToTeamConfigs, actualRepoNameToTeamConfigs)
+			mockClient.AssertExpectations(t)
+		})
 	}
-
-	mockClient.On("ListTeamReposBySlugIter", testContext, mockOrgName, mockTeamSlug, nil).Return(
-		maps.All(mockRepoMap),
-	)
-
-	actualRepoNameToTeamConfig := cql.getRepoNameToTeamConfig(testLogger)
-
-	expectedRepoNameToTeamConfig := map[string]configs.TeamConfig{
-		mockRepo: mockTeam,
-	}
-	assert.Equal(t, expectedRepoNameToTeamConfig, actualRepoNameToTeamConfig)
-
-	mockClient.AssertExpectations(t)
 }

--- a/querying/github.go
+++ b/querying/github.go
@@ -2,7 +2,6 @@ package querying
 
 import (
 	"context"
-	"strings"
 	"sync"
 
 	"golang.org/x/oauth2"
@@ -12,8 +11,6 @@ import (
 	"github.com/underdog-tech/vulnbot/configs"
 	"github.com/underdog-tech/vulnbot/logger"
 )
-
-const DisableVulnBotTopicKeyword = "disable-vulnbot"
 
 type githubClient interface {
 	Query(context.Context, interface{}, map[string]interface{}) error
@@ -192,8 +189,11 @@ func (gh *GithubDataSource) processRepoOwners(ownerQuery *orgRepoOwnerQuery, pro
 			continue
 		}
 		for _, repo := range team.Repositories.Edges {
-			shouldIgnoreRepo := repo.Node.IsArchived || repo.Node.IsFork || hasDisableVulnbotTopic(repo.Node.RepositoryTopics)
-			if shouldIgnoreRepo {
+			if shouldIgnoreRepository(
+				repo.Node.IsArchived,
+				repo.Node.IsFork,
+				repo.Node.RepositoryTopics.names(),
+			) {
 				log.Debug().
 					Str("Repo", repo.Node.Name).
 					Bool("IsFork", repo.Node.IsFork).
@@ -210,14 +210,4 @@ func (gh *GithubDataSource) processRepoOwners(ownerQuery *orgRepoOwnerQuery, pro
 			}
 		}
 	}
-}
-
-// Function to check if the repository has "disable-vulnbot" in its topics
-func hasDisableVulnbotTopic(repoTopics repositoryTopics) bool {
-	for _, edge := range repoTopics.Edges {
-		if strings.Contains(strings.ToLower(edge.Node.Topic.Name), DisableVulnBotTopicKeyword) {
-			return true
-		}
-	}
-	return false
 }

--- a/querying/queries.go
+++ b/querying/queries.go
@@ -29,6 +29,14 @@ type repositoryTopics struct {
 	}
 }
 
+func (topics repositoryTopics) names() []string {
+	names := make([]string, 0, len(topics.Edges))
+	for _, edge := range topics.Edges {
+		names = append(names, edge.Node.Topic.Name)
+	}
+	return names
+}
+
 type orgRepo struct {
 	Name                string
 	Url                 string

--- a/querying/repository.go
+++ b/querying/repository.go
@@ -1,0 +1,17 @@
+package querying
+
+import "strings"
+
+const DisableVulnBotTopicKeyword = "disable-vulnbot"
+
+func shouldIgnoreRepository(isArchived bool, isFork bool, topics []string) bool {
+	if isArchived || isFork {
+		return true
+	}
+	for _, topic := range topics {
+		if strings.Contains(strings.ToLower(topic), DisableVulnBotTopicKeyword) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- require `ADMIN` or `MAINTAIN` team repository permission for CodeQL ownership
- preserve every qualifying team owner instead of overwriting by configuration order
- exclude write-only teams from CodeQL reports
- share Dependabot repository exclusion policy with CodeQL for archived repositories, forks, and `disable-vulnbot` topics

## Context

The CodeQL repository map previously treated every configured team with repository access as an owner and retained only the last matching team. This caused repositories such as `hub-api-python` to appear in a write-only team’s Slack report. CodeQL also did not apply Dependabot’s repository exclusions.